### PR TITLE
introduce a VersionNegotiationError

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -376,6 +376,7 @@ multiple error codes can be set on the same event to reflect this.
     connection_code?:TransportError | CryptoError | uint32,
     application_code?:ApplicationError | uint32,
     internal_code?:uint32,
+    version_negotiation: Array<bytes>,
 
     reason?:string
 }


### PR DESCRIPTION
When a client receives a Version Negotiation packet indicating that there's no commonly supported version, it aborts the connection attempt. Currently, qlog doesn't allow to log this.