### PR TITLE
Rename stream_id to id for the GOAWAY frame

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -634,7 +634,7 @@ class PushPromiseFrame{
 ~~~
 class GoAwayFrame{
     frame_type:string = "goaway";
-    stream_id:uint64;
+    id:uint64; // either stream_id or push_id. This is implicit from the sender of the frame.
 }
 ~~~
 


### PR DESCRIPTION
Fixes #160. Oversight when keeping up with the latest H3 drafts.