### PR TITLE
Fix main schema build errors and wrapping

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -244,7 +244,6 @@ JSON serialization example:
     "traces": [...]
 }
 ~~~~~~~~
-{: .language-json}
 {: #top-element title="Top-level element"}
 
 ## summary
@@ -282,7 +281,6 @@ JSON serialization:
     "error_count": 2
 }
 ~~~
-{: .language-json}
 {: #summary-example title="Summary example definition"}
 
 
@@ -324,7 +322,6 @@ JSON serialization:
     "vantage_point": { type: "server" }
 }
 ~~~
-{: .language-json}
 {: #trace-error title="TraceError definition"}
 
 Note that another way to combine events of different traces in a single qlog file
@@ -377,7 +374,6 @@ JSON serialization:
     "events": [...]
 }
 ~~~~~~~~
-{: .language-json}
 {: #trace-container title="Trace container definition"}
 
 ### configuration
@@ -413,7 +409,6 @@ JSON serialization:
     ]
 }
 ~~~~~~~~
-{: .language-json}
 {: #configuration_example title="Configuration definition"}
 
 
@@ -501,7 +496,6 @@ JSON serialization examples:
     "flow": "client"
 }
 ~~~~~~~~
-{: .language-json}
 {: #vantage-point-example title="VantagePoint definition"}
 
 The flow field is only required if the type is "network" (for example, the trace
@@ -583,7 +577,6 @@ JSON serialization:
     ODCID: "127ecc830d98f9d54a42c4f0842aa87e181a", // QUIC specific
 }
 ~~~~~~~~
-{: .language-json}
 {: #event-definition title="Event fields definition"}
 
 ### timestamps {#time-based-fields}
@@ -724,7 +717,6 @@ JSON serialization:
     ]
 }
 ~~~~~~~~
-{: .language-json}
 {: #data-example title="Example of the 'data' field for a QUIC packet_sent event"}
 
 ### protocol_type {#protocol-type-field}
@@ -772,7 +764,6 @@ class QuicPacketDroppedEvent {
     trigger?: "key_unavailable" | "unknown_connection_id" | "decrypt_error" | "unsupported_version"
 }
 ~~~~~~~~
-{: .language-json}
 {: #trigger-example title="Trigger example"}
 
 ### group_id {#group-ids}
@@ -819,7 +810,6 @@ events: [
     }
 ]
 ~~~~~~~~
-{: .language-json}
 {: #group-id-example title="Example of group_id usage"}
 
 Note that in some contexts (for example a Multipath transport protocol) it might
@@ -895,7 +885,6 @@ JSON serialization with repeated field values extracted to common_fields:
     ]
 }
 ~~~~~~~~
-{: .language-json}
 {: #common-fields-example title="Example of common_fields usage"}
 
 The "common_fields" field is a generic dictionary of key-value pairs, where the
@@ -1300,7 +1289,6 @@ serialization is:
     raw: "051428abff"
 }
 ~~~~~~~~
-{: .language-json}
 {: #json-bytes-example title="Example for serializing bytes"}
 
 As such, the resulting string will always have an even amount of characters and
@@ -1349,7 +1337,6 @@ by example in {{json-bytes-example-two}}.
 }
 
 ~~~~~~~~
-{: .language-json}
 {: #json-bytes-example-two title="Example for serializing truncated bytes"}
 
 
@@ -1481,7 +1468,6 @@ JSON-SEQ serialization example:
 <RS>{"time": 7, "name": "http:frame_parsed", "data": { ... } }
 ...
 ~~~~~~~~
-{: .language-json}
 {: #json-seq-example title="Top-level element"}
 
 Note: while not specifically required by the JSON-SEQ specification, all qlog
@@ -1771,7 +1757,6 @@ Should result in the the quicserverbinary executable logging a single qlog file 
 Given that the server handled two QUIC connections before it was shut down, with ODCID values "abcde" and "12345" respectively,
 this would result in event instances in the qlog file being tagged with the "group_id" field with values "abcde" and "12345".
 ~~~~~~~~
-{: .language-json}
 {: #qlogdir-example title="Environment variable examples for a QUIC implementation"}
 
 ## Access logs via a well-known endpoint

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -265,10 +265,15 @@ Definition (purely illustrative example):
 
 class Summary {
     "trace_count":uint32, // amount of traces in this file
-    "max_duration":uint64, // time duration of the longest trace in ms
-    "max_outgoing_loss_rate":float, // highest loss rate for outgoing packets over all traces
-    "total_event_count":uint64, // total number of events across all traces,
-    "error_count":uint64 // total number of error events in this trace
+    "max_duration":uint64, // time duration of the longest
+                           // trace in ms
+    "max_outgoing_loss_rate":float, // highest loss rate
+                                    // for outgoing packets
+                                    // over all traces
+    "total_event_count":uint64, // total number of events
+                                // across all traces,
+    "error_count":uint64 // total number of error events in
+                         // this trace
 }
 
 JSON serialization:
@@ -310,8 +315,11 @@ Definition:
 
 class TraceError {
     error_description: string, // A description of the error
-    uri?: string, // the original URI at which we attempted to find the file
-    vantage_point?: VantagePoint // see {{vantage_point}}: the vantage point we were expecting to include here
+    uri?: string, // the original URI at which we attempted to
+                  // find the file
+    vantage_point?: VantagePoint // see {{vantage_point}}:
+                                 // the vantage point we were
+                                 // expecting to include here
 }
 
 JSON serialization:
@@ -402,7 +410,7 @@ class Configuration {
 JSON serialization:
 
 {
-    "time_offset": 150, // starts 150ms after the first timestamp indicates
+    "time_offset": 150,
     "original_uris": [
         "https://example.org/trace1.qlog",
         "https://example.org/trace2.qlog"
@@ -439,17 +447,12 @@ Two examples from the [qvis toolset](https://qvis.edm.uhasselt.be) are shown in
 {
     "configuration" : {
         "qvis" : {
-            // when loaded into the qvis toolsuite's congestion graph tool
-            // zoom in on the period between 1s and 2s and select the 124th event defined in this trace
             "congestion_graph": {
                 "startX": 1000,
                 "endX": 2000,
                 "focusOnEventIndex": 124
             }
 
-
-            // when loaded into the qvis toolsuite's sequence diagram tool
-            // automatically scroll down the timeline to the 555th event defined in this trace
             "sequence_diagram" : {
                 "focusOnEventIndex": 555
             }
@@ -761,7 +764,8 @@ class QuicPacketDroppedEvent {
     packet_type?:PacketType,
     raw_length?:uint32,
 
-    trigger?: "key_unavailable" | "unknown_connection_id" | "decrypt_error" | "unsupported_version"
+    trigger?: "key_unavailable" | "unknown_connection_id" |
+              "decrypt_error" | "unsupported_version"
 }
 ~~~~~~~~
 {: #trigger-example title="Trigger example"}
@@ -791,13 +795,15 @@ serialization for this field, so long as it contains a unique value per logical
 group. Some examples can be seen in {{group-id-example}}.
 
 ~~~~~~~~
-JSON serialization for events grouped by four tuples and QUIC connection IDs:
+JSON serialization for events grouped by four tuples
+and QUIC connection IDs:
 
 events: [
     {
         time: 1553986553579,
         protocol_type: ["TCP", "TLS", "HTTP2"],
-        group_id: "ip1=2001:67c:1232:144:9498:6df6:f450:110b,ip2=2001:67c:2b0:1c1::198,port1=59105,port2=80",
+        group_id: "ip1=2001:67c:1232:144:9498:6df6:f450:110b,
+                   ip2=2001:67c:2b0:1c1::198,port1=59105,port2=80",
         name: "transport:packet_received",
         data: { ... },
     },
@@ -838,7 +844,8 @@ component trace. This prevents these fields from being logged for each individua
 event. An example of this is shown in {{common-fields-example}}.
 
 ~~~~~~~~
-JSON serialization with repeated field values per-event instance:
+JSON serialization with repeated field values
+per-event instance:
 
 {
     events: [{
@@ -863,7 +870,8 @@ JSON serialization with repeated field values per-event instance:
     ]
 }
 
-JSON serialization with repeated field values extracted to common_fields:
+JSON serialization with repeated field values
+extracted to common_fields:
 
 {
     common_fields: {
@@ -1034,10 +1042,15 @@ applicable).
 
 ~~~
 class RawInfo {
-    length?:uint64; // the full byte length of the entity (e.g., packet or frame) including headers and trailers
-    payload_length?:uint64; // the byte length of the entity's payload, without headers or trailers
+    length?:uint64; // the full byte length of the entity
+                    // (e.g., packet or frame) including
+                    // headers and trailers
+    payload_length?:uint64; // the byte length of the
+                            // entity's payload, without
+                            // headers or trailers
 
-    data?:bytes; // the contents of the full entity, including headers and trailers
+    data?:bytes; // the contents of the full entity,
+                 // including headers and trailers
 }
 ~~~
 
@@ -1282,8 +1295,8 @@ prefixed with 0x (as is sometimes common). An example is given in
 {{json-bytes-example}}.
 
 ~~~~~~~~
-For the five raw unsigned byte input values of: 5 20 40 171 255, the JSON
-serialization is:
+For the five raw unsigned byte input values of:
+5 20 40 171 255, the JSON serialization is:
 
 {
     raw: "051428abff"
@@ -1312,19 +1325,22 @@ separate length-indicating field is present. All possible permutations are shown
 by example in {{json-bytes-example-two}}.
 
 ~~~~~~~~
-// both the full raw value and its length are present (length is redundant)
+// both the full raw value and its length are present
+// (length is redundant)
 {
     "raw_length": 5,
     "raw": "051428abff"
 }
 
-// only the raw value is present, indicating it represents the fields full value
-// the byte length is obtained by calculating raw.length / 2
+// only the raw value is present, indicating it
+// represents the fields full value the byte
+// length is obtained by calculating raw.length / 2
 {
     "raw": "051428abff"
 }
 
-// only the length field is present, meaning the value was omitted
+// only the length field is present, meaning the
+// value was omitted
 {
     "raw_length": 5,
 }
@@ -1438,7 +1454,8 @@ class QlogFileSeq {
 }
 
 // list of qlog events, serialized in accordance with RFC 7464,
-// starting with a Record Separator character and ending with a newline.
+// starting with a Record Separator character and ending with a
+// newline.
 // For display purposes, Record Separators are rendered as <RS>
 
 JSON-SEQ serialization example:
@@ -1446,7 +1463,7 @@ JSON-SEQ serialization example:
 <RS>{
     "qlog_version": "0.3",
     "qlog_format": "JSON-SEQ",
-    "title": "Name of this particular JSON Text Sequence qlog file (short)",
+    "title": "Name of JSON Text Sequence qlog file (short)",
     "description": "Description for this trace file (long)",
     "summary": {
         ...
@@ -1464,8 +1481,8 @@ JSON-SEQ serialization example:
       }
     }
 }
-<RS>{"time": 2, "name": "transport:packet_received", "data": { ... } }
-<RS>{"time": 7, "name": "http:frame_parsed", "data": { ... } }
+<RS>{"time": 2, "name": "transport:parameters_set", "data": { ... } }
+<RS>{"time": 7, "name": "transport:packet_sent", "data": { ... } }
 ...
 ~~~~~~~~
 {: #json-seq-example title="Top-level element"}
@@ -1741,21 +1758,28 @@ the logging endpoint. Examples of all options for QUIC are shown in
 ~~~~~~~~
 Command: QLOGFILE=/srv/qlogs/client.qlog quicclientbinary
 
-Should result in the the quicclientbinary executable logging a single qlog file named client.qlog in the /srv/qlogs directory.
-This is for example useful in tests when the client sets up just a single connection and then exits.
+Should result in the the quicclientbinary executable logging a
+single qlog file named client.qlog in the /srv/qlogs directory.
+This is for example useful in tests when the client sets up
+just a single connection and then exits.
 
 Command: QLOGDIR=/srv/qlogs/ quicserverbinary
 
-Should result in the quicserverbinary executable generating several logs files, one for each QUIC connection.
-Given two QUIC connections, with ODCID values "abcde" and "12345" respectively, this would result in two files:
+Should result in the quicserverbinary executable generating
+several logs files, one for each QUIC connection.
+Given two QUIC connections, with ODCID values "abcde" and
+"12345" respectively, this would result in two files:
 /srv/qlogs/abcde_server.qlog
 /srv/qlogs/12345_server.qlog
 
 Command: QLOGFILE=/srv/qlogs/server.qlog quicserverbinary
 
-Should result in the the quicserverbinary executable logging a single qlog file named server.qlog in the /srv/qlogs directory.
-Given that the server handled two QUIC connections before it was shut down, with ODCID values "abcde" and "12345" respectively,
-this would result in event instances in the qlog file being tagged with the "group_id" field with values "abcde" and "12345".
+Should result in the the quicserverbinary executable logging
+a single qlog file named server.qlog in the /srv/qlogs directory.
+Given that the server handled two QUIC connections before it was
+shut down, with ODCID values "abcde" and "12345" respectively,
+this would result in event instances in the qlog file being
+tagged with the "group_id" field with values "abcde" and "12345".
 ~~~~~~~~
 {: #qlogdir-example title="Environment variable examples for a QUIC implementation"}
 


### PR DESCRIPTION
- main: temporarily remove {: .language-json} tags until diagrams are changed
- main: wrap lines to appease xml2rfc

Helps address part of #188.

In this spec, you have a fundamental problem that the json in examples is malformed and kramdown complains. So let's just disable that for now. 

The rest of the changes are tedious but also not too onerous. The main issue you have is that there's lots of comments here and there that break length limits. So I've just picked a line length that will appease xml2rfc. 

In some cases, you have comments inside JSON, which won't work. In one case I deleted some because the qlog properties might get deleted anyway.

The changes you have in mind might have obviated the errors anyway. But if not, these changes will set a strong foundation to know how to shut xml2rfc up.