### PR TITLE
Improve referencing

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -32,37 +32,8 @@ author:
 
 normative:
 
-  QUIC-HTTP:
-    title: "Hypertext Transfer Protocol Version 3 (HTTP/3)"
-    date: {DATE}
-    seriesinfo:
-      Internet-Draft: draft-ietf-quic-http-latest
-    author:
-      -
-          ins: M. Bishop
-          name: Mike Bishop
-          org: Akamai Technologies
-          role: editor
-
-  QUIC-QPACK:
-    title: "QPACK: Header Compression for HTTP over QUIC"
-    date: {DATE}
-    seriesinfo:
-      Internet-Draft: draft-ietf-quic-qpack-latest
-    author:
-      -
-          ins: C. Krasic
-          name: Charles 'Buck' Krasic
-          org: Google, Inc
-      -
-          ins: M. Bishop
-          name: Mike Bishop
-          org: Akamai Technologies
-      -
-          ins: A. Frindell
-          name: Alan Frindell
-          org: Facebook
-          role: editor
+  RFC9114:
+    display: HTTP/3
 
   QLOG-MAIN:
     title: "Main logging schema for qlog"
@@ -114,17 +85,15 @@ informative:
 
 This document describes concrete qlog event definitions and their metadata for
 HTTP/3 and QPACK-related events. These events can then be embedded in the higher
-level schema defined in [QLOG-MAIN].
+level schema defined in {{QLOG-MAIN}}.
 
 --- middle
 
 # Introduction
 
 This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the HTTP/3 and QPACK protocols. This
-document is based on draft-34 of the HTTP/3 I-D [QUIC-HTTP] and draft-21 of the
-QPACK I-D [QUIC-QPACK]. QUIC events are defined in a separate document
-[QLOG-QUIC].
+"data" fields and their semantics for HTTP/3 {{RFC9114}} and QPACK
+{{!QPACK=RFC9204}}.
 
 Feedback and discussion are welcome at
 [https://github.com/quicwg/qlog](https://github.com/quicwg/qlog).
@@ -143,7 +112,7 @@ interpreted as described in {{?RFC2119}}.
 
 The event and data structure definitions in ths document are expressed
 in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
-extensions described in [QLOG-MAIN].
+extensions described in {{QLOG-MAIN}}.
 
 # Overview
 
@@ -151,7 +120,7 @@ This document describes the values of the qlog "name" ("category" + "event") and
 "data" fields and their semantics for the HTTP/3 and QPACK protocols.
 
 This document assumes the usage of the encompassing main qlog schema defined in
-[QLOG-MAIN]. Each subsection below defines a separate category (for example http,
+{{QLOG-MAIN}}. Each subsection below defines a separate category (for example http,
 qpack) and each subsubsection is an event type (for example `frame_created`).
 
 For each event type, its importance and data definition is laid out, often
@@ -165,7 +134,7 @@ together on the bottom of this document for clarity.
 ## Usage with QUIC
 
 The events described in this document can be used with or without logging the
-related QUIC events defined in [QLOG-QUIC]. If used with QUIC events, the QUIC
+related QUIC events defined in {{QLOG-QUIC}}. If used with QUIC events, the QUIC
 document takes precedence in terms of recommended filenames and trace separation
 setups.
 
@@ -187,7 +156,7 @@ this document are included in a qlog trace.
 
 ### Raw packet and frame information
 
-This document re-uses the definition of the RawInfo data class from [QLOG-MAIN].
+This document re-uses the definition of the RawInfo data class from {{QLOG-MAIN}}.
 
 Note:
 
@@ -331,7 +300,7 @@ Importance: Core
 HTTP equivalent to the packet_sent event. This event is emitted when the HTTP/3
 framing actually happens. Note: this is not necessarily the same as when the
 HTTP/3 data is passed on to the QUIC layer. For that, see the "data_moved" event
-in [QLOG-QUIC].
+in {{QLOG-QUIC}}.
 
 Definition:
 
@@ -357,7 +326,7 @@ Importance: Core
 HTTP equivalent to the packet_received event. This event is emitted when we
 actually parse the HTTP/3 frame. Note: this is not necessarily the same as when
 the HTTP/3 data is actually received on the QUIC layer. For that, see the
-"data_moved" event in [QLOG-QUIC].
+"data_moved" event in {{QLOG-QUIC}}.
 
 
 Definition:
@@ -599,7 +568,7 @@ TBD
 ## ProtocolEventBody extension
 
 We extend the `$ProtocolEventBody` extension point defined in
-[QLOG-MAIN] with the HTTP/3 protocol events defined in this document.
+{{QLOG-MAIN}} with the HTTP/3 protocol events defined in this document.
 
 ~~~ cddl
 HTTPEvents = HTTPParametersSet / HTTPParametersRestored /
@@ -760,7 +729,7 @@ HTTPReservedFrame = {
 ### UnknownFrame
 
 HTTP/3 qlog re-uses QUIC's UnknownFrame definition, since their values
-and usage overlaps. See [QLOG-QUIC].
+and usage overlaps. See {{QLOG-QUIC}}.
 
 ## ApplicationError
 
@@ -786,7 +755,7 @@ HTTPApplicationError =  "http_no_error" /
 {: #httpapplicationerror-def title="HTTPApplicationError definition"}
 
 The HTTPApplicationError defines the general $ApplicationError
-definition in the qlog QUIC definition, see [QLOG-QUIC].
+definition in the qlog QUIC definition, see {{QLOG-QUIC}}.
 
 ~~~ cddl
 ; ensure HTTP errors are properly validate in QUIC events as well
@@ -799,7 +768,7 @@ $ApplicationError /= HTTPApplicationError
 ## ProtocolEventBody extension
 
 We extend the `$ProtocolEventBody` extension point defined in
-[QLOG-MAIN] with the QPACK protocol events defined in this document.
+{{QLOG-MAIN}} with the QPACK protocol events defined in this document.
 
 ~~~ cddl
 QPACKEvents = QPACKStateUpdate / QPACKStreamStateUpdate /

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -32,6 +32,8 @@ author:
     role: editor
 
 normative:
+
+informative:
   QLOG-QUIC:
     title: "QUIC event definitions for qlog"
     date: {DATE}
@@ -76,7 +78,6 @@ normative:
         org: Protocol Labs
         role: editor
 
-informative:
 
 --- abstract
 
@@ -100,7 +101,7 @@ This document aims to provide a high-level schema and harness that describes the
 general layout of an easily usable, shareable, aggregatable and structured logging
 format. This high-level schema is protocol agnostic, with logging entries for
 specific protocols and use cases being defined in other documents (see for example
-[QLOG-QUIC] for QUIC and [QLOG-H3] for HTTP/3 and QPACK-related event
+{{QLOG-QUIC}} for QUIC and {{QLOG-H3}} for HTTP/3 and QPACK-related event
 definitions).
 
 The goal of this high-level schema is to provide amenities and default
@@ -565,12 +566,13 @@ they are normally logged separately in the "common_fields" ({{common-fields}}).
 
 The specific values for each of these fields and their semantics are defined in
 separate documents, specific per protocol or use case. For example: event
-definitions for QUIC, HTTP/3 and QPACK can be found in [QLOG-QUIC] and [QLOG-H3].
+definitions for QUIC, HTTP/3 and QPACK can be found in {{QLOG-QUIC}} and
+{{QLOG-H3}}.
 
 Other fields are explicitly allowed by the qlog approach, and tools SHOULD allow
 for the presence of unknown event fields, but their semantics depend on the
 context of the log usage (e.g., for QUIC, the ODCID field is used), see
-[QLOG-QUIC].
+{{QLOG-QUIC}}.
 
 An example of a qlog event with its component fields is shown in
 {{event-def}}.
@@ -722,8 +724,9 @@ encouraged to employ the concatenated "name" field for efficiency.
 ### Data {#data-field}
 
 The data field is a generic object. It contains the per-event metadata and its
-form and semantics are defined per specific sort of event. For example, data field
-value definitions for QUIC and HTTP/3 can be found in [QLOG-QUIC] and [QLOG-H3].
+form and semantics are defined per specific sort of event. For example, data
+field value definitions for QUIC and HTTP/3 can be found in {{QLOG-QUIC}} and
+{{QLOG-H3}}.
 
 This field is defined here as a CDDL extension point (a "socket" or
 "plug") named `$ProtocolEventBody`. Other documents MUST properly extend
@@ -796,7 +799,7 @@ ProtocolType = [+ text]
 {: #protocol-type-def title="ProtocolType definition"}
 
 For example, QUIC and HTTP/3 events have the "QUIC" and "HTTP3" protocol_type
-entry values, see [QLOG-QUIC] and [QLOG-H3].
+entry values, see {{QLOG-QUIC}} and {{QLOG-H3}}.
 
 Typically however, all events in a single trace are of the same few protocols, and
 this array field is logged once in "common_fields", see {{common-fields}}.
@@ -1005,8 +1008,8 @@ This document only defines the main schema for the qlog format. This is intended
 to be used together with specific, per-protocol event definitions that specify the
 name (category + type) and data needed for each individual event. This is with the
 intent to allow the qlog main schema to be easily re-used for several protocols.
-Examples include the QUIC event definitions [QLOG-QUIC] and HTTP/3 and QPACK
-event definitions [QLOG-H3].
+Examples include the QUIC event definitions {{QLOG-QUIC}} and HTTP/3 and QPACK
+event definitions {{QLOG-H3}}.
 
 This section defines some basic annotations and concepts the creators of event
 definition documents SHOULD follow to ensure a measure of consistency, making it
@@ -1717,7 +1720,7 @@ compressed textual JSON options are a better default for the qlog format in
 general.
 
 {::comment} The definition of the qlog main schema and existing event type
-documents (for example [QLOG-QUIC] [QLOG-H3]) should allow a relatively easy qlog
+documents (for example {{QLOG-QUIC}} {{QLOG-H3}}) should allow a relatively easy qlog
 definition in a variety of binary format schemas. {:/comment}
 
 ### Overview and summary {#format-summary}

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -32,87 +32,11 @@ author:
 
 normative:
 
-  QUIC-TRANSPORT:
-    title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
-    date: 2021-05
-    seriesinfo:
-      RFC: 9000
-      DOI: 10.17487/RFC9000
-    author:
-      -
-        ins: J. Iyengar
-        name: Jana Iyengar
-        org: Fastly
-        role: editor
-      -
-        ins: M. Thomson
-        name: Martin Thomson
-        org: Mozilla
-        role: editor
-
-  QUIC-RECOVERY:
-    title: "QUIC Loss Detection and Congestion Control"
-    date: 2021-05
-    seriesinfo:
-      RFC: 9002
-      DOI: 10.17487/RFC9002
-    author:
-      -
-        ins: J. Iyengar
-        name: Jana Iyengar
-        org: Fastly
-        role: editor
-      -
-        ins: I. Swett
-        name: Ian Swett
-        org: Google
-        role: editor
-
-  QUIC-TLS:
-    title: "Using TLS to Secure QUIC"
-    date: 2021-05
-    seriesinfo:
-      RFC: 9001
-      DOI: 10.17487/RFC9001
-    author:
-      -
-        ins: M. Thomson
-        name: Martin Thomson
-        org: Mozilla
-        role: editor
-      -
-        ins: S. Turner
-        name: Sean Turner
-        org: sn3rd
-        role: editor
-
   QLOG-MAIN:
     title: "Main logging schema for qlog"
     date: {DATE}
     seriesinfo:
       Internet-Draft: draft-ietf-quic-qlog-main-schema-latest
-    author:
-      -
-        ins: R. Marx
-        name: Robin Marx
-        org: KU Leuven
-        role: editor
-      -
-        ins: L. Niccolini
-        name: Luca Niccolini
-        org: Facebook
-        role: editor
-      -
-        ins: M. Seemann
-        name: Marten Seemann
-        org: Protocol Labs
-        role: editor
-
-  QLOG-H3:
-    title: "HTTP/3 and QPACK event definitions for qlog"
-    date: {DATE}
-    seriesinfo:
-      Internet-Draft: draft-ietf-quic-qlog-h3-events-latest
     author:
       -
         ins: R. Marx
@@ -136,16 +60,15 @@ informative:
 
 This document describes concrete qlog event definitions and their metadata for
 QUIC events. These events can then be embedded in the higher level schema defined
-in [QLOG-MAIN].
+in {{QLOG-MAIN}}.
 
 --- middle
 
 # Introduction
 
 This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the QUIC protocol. This document is based on
-draft-34 of the QUIC I-Ds [QUIC-TRANSPORT], [QUIC-RECOVERY], and [QUIC-TLS]. HTTP/3 and
-QPACK events are defined in a separate document [QLOG-H3].
+"data" fields and their semantics for QUIC; see {{!QUIC-TRANSPORT=RFC9000}},
+{{!QUIC-RECOVERY=RFC9002}}, and {{!QUIC-TLS=RFC9003}}.
 
 Feedback and discussion are welcome at
 [https://github.com/quicwg/qlog](https://github.com/quicwg/qlog).
@@ -164,7 +87,7 @@ interpreted as described in {{?RFC2119}}.
 
 The event and data structure definitions in ths document are expressed
 in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
-extensions described in [QLOG-MAIN].
+extensions described in {{QLOG-MAIN}}.
 
 # Overview
 
@@ -172,7 +95,7 @@ This document describes the values of the qlog "name" ("category" + "event") and
 "data" fields and their semantics for the QUIC protocol.
 
 This document assumes the usage of the encompassing main qlog schema defined in
-[QLOG-MAIN]. Each subsection below defines a separate category (for example
+{{QLOG-MAIN}}. Each subsection below defines a separate category (for example
 connectivity, transport, recovery) and each subsubsection is an event type (for
 example `packet_received`).
 
@@ -204,7 +127,7 @@ trace of the connection with ODCID abcd1234).
 
 ### Raw packet and frame information
 
-This document re-uses the definition of the RawInfo data class from [QLOG-MAIN].
+This document re-uses the definition of the RawInfo data class from {{QLOG-MAIN}}.
 
 Note:
 
@@ -1406,7 +1329,7 @@ TBD
 ## ProtocolEventBody extension
 
 We extend the `$ProtocolEventBody` extension point defined in
-[QLOG-MAIN] with the QUIC protocol events defined in this document.
+{{QLOG-MAIN}} with the QUIC protocol events defined in this document.
 
 ~~~ cddl
 QuicEvents = ConnectivityServerListening /


### PR DESCRIPTION
First, these documents can now refer to the published QUIC RFCs.

While doing that, let's just replace all [REF] with {{REF}}, which
works better for our tooling.

Lastly, lets brush up the cross references between documents a bit.

Closes #216 
