### PR TITLE
Define HTTPUnknownFrame type for H3

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -599,7 +599,7 @@ HTTPFrame =  HTTPDataFrame /
              HTTPGoawayFrame /
              HTTPMaxPushIDFrame /
              HTTPReservedFrame /
-             UnknownFrame
+             HTTPUnknownFrame
 ~~~
 {: #httpframe-def title="HTTPFrame definition"}
 
@@ -729,8 +729,16 @@ HTTPReservedFrame = {
 
 ### UnknownFrame
 
-HTTP/3 qlog re-uses QUIC's UnknownFrame definition, since their values
-and usage overlaps. See {{QLOG-QUIC}}.
+~~~ cddl
+HTTPUnknownFrame = {
+    frame_type: "unknown"
+    raw_frame_type: uint64
+
+    ? raw_length: uint32
+    ? raw: hexstring
+}
+~~~
+{: #httpunknownframe-def title="UnknownFrame definition"}
 
 ## ApplicationError
 


### PR DESCRIPTION
Avoid confusing use of QUIC's UnknownFrame type.

Fixes #201
