### PR TITLE
Notational conventions aren't the place to discuss

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -184,15 +184,8 @@ Other qlog documents can define their own CDDL-compatible (struct) types
 
 ### Serialization
 
-While the qlog schemas are format-agnostic, and can be serialized in
-many ways (e.g., JSON, CBOR, protobuf, ...), this document only
-describes how to employ {{!JSON=RFC8259}}, its subset
-{{!I-JSON=RFC7493}}, and its streamable derivative
-{{!JSON-Text-Sequences=RFC7464}} as textual serialization options. As
-such, examples are provided in {{!JSON=RFC8259}}. Other documents may
-describe how to utilize other concrete serialization options, though
-tips and requirements for these are also listed in this document
-({{concrete-formats}}).
+The qlog schema can be serialized in many ways (e.g., JSON, CBOR, protobuf,
+etc). Serialization examples in this document use JSON ({{!JSON=RFC8259}}).
 
 # Design goals
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -112,6 +112,11 @@ with logs from a variety of different protocols and use cases.
 As such, this document contains concepts such as versioning, metadata inclusion,
 log aggregation, event grouping and log file size reduction techniques.
 
+The qlog schema can be serialized in many ways (e.g., JSON, CBOR, protobuf,
+etc). This document describes only how to employ {{!JSON=RFC8259}}, its subset
+{{!I-JSON=RFC7493}}, and its streamable derivative
+{{!JSON-Text-Sequences=RFC7464}}.
+
 > Note to RFC editor: Please remove the follow paragraphs in this section before
 publication.
 
@@ -182,10 +187,10 @@ logged as `float64` in the millisecond resolution.
 Other qlog documents can define their own CDDL-compatible (struct) types
 (e.g., separately for each Packet type that a protocol supports).
 
-### Serialization
+### Serialization examples
 
-The qlog schema can be serialized in many ways (e.g., JSON, CBOR, protobuf,
-etc). Serialization examples in this document use JSON ({{!JSON=RFC8259}}).
+Serialization examples in this document use JSON ({{!JSON=RFC8259}}) unless
+otherwise indicated.
 
 # Design goals
 


### PR DESCRIPTION
There's too much text here that doesn't aid the reader. Delete it to be
clear that we're using JSON as the notational convention for examples.

If this text was valuable, it should be somewhere else.
