### PR TITLE
Update MTU event definitions

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -426,15 +426,16 @@ For now, infer from other connectivity events and path_challenge/path_response f
 Importance: Extra
 
 ~~~ ccdl
-MTUUpdated = {
-  ? mtu: uint16
+ConnectivityMTUUpdated = {
+  ? old: uint16
+  new: uint16
 
   ; at some point, MTU discovery stops, as a "good enough"
   ; packet size has been found
   ? done: bool .default false
 }
 ~~~
-{: #mtu-updated-def title="MTUUpdated definition"}
+{: #connectivity-mtu-updated-def title="ConnectivityMTUUpdated definition"}
 
 This event indicates that the estimated Path MTU was updated. This happens as
 part of the Path MTU discovery process.
@@ -1347,6 +1348,7 @@ QuicEvents = ConnectivityServerListening /
              ConnectivityConnectionIDUpdated /
              ConnectivitySpinBitUpdated /
              ConnectivityConnectionStateUpdated /
+             ConnectivityMTUUpdated /
              SecurityKeyUpdated / SecurityKeyDiscarded /
              TransportVersionInformation / TransportALPNInformation /
              TransportParametersSet / TransportParametersRestored /

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -422,6 +422,23 @@ TODO: integrate https://tools.ietf.org/html/draft-deconinck-quic-multipath-02
 
 For now, infer from other connectivity events and path_challenge/path_response frames
 
+### mtu_updated
+Importance: Extra
+
+~~~ ccdl
+MTUUpdated = {
+  ? mtu: uint16
+
+  ; at some point, MTU discovery stops, as a "good enough"
+  ; packet size has been found
+  ? done: bool .default false
+}
+~~~
+{: #mtu-updated-def title="MTUUpdated definition"}
+
+This event indicates that the estimated Path MTU was updated. This happens as
+part of the Path MTU discovery process.
+
 ## security
 
 ### key_updated
@@ -1259,7 +1276,7 @@ RecoveryPacketLost = {
     ; see appendix for the QuicFrame definitions
     ? frames: [* QuicFrame]
 
-    ? is_mtu_probe_packet: boolean .default false
+    ? is_mtu_probe_packet: bool .default false
 
     ? trigger:
         "reordering_threshold" /
@@ -1304,23 +1321,6 @@ RecoveryMarkedForRetransmit = {
 }
 ~~~
 {: #recovery-markedforretransmit-def title="RecoveryMarkedForRetransmit definition"}
-
-## mtu_updated
-Importance: Extra
-
-~~~ ccdl
-MTUUpdated = {
-  ? mtu: uint16
-
-  ; at some point, MTU discovery stops, as a "good enough"
-  ; packet size has been found
-  ? done: boolean .default false
-}
-~~~
-{: #mtu-updated-def title="MTUUpdated definition"}
-
-This event indicates that the estimated Path MTU was updated. This happens as
-part of the Path MTU discovery process.
 
 
 # Security Considerations


### PR DESCRIPTION
Updates #210 as that had some problems:

- used `boolean` instead of `bool` for CDDL type in some of the definitions (not in others)...
- Made a separate category for the `mtu_updated` event. It's debatable imo whether it belongs in `connectivity` or `transport`, but it shouldn't be its own thing. 

In general, I feel #210 was approved/merged too soon and this type of things should be checked for future PRs of a similar type. 