### PR TITLE
H3 CDDL: use consistent spacing

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -191,9 +191,7 @@ Definition:
 ~~~ cddl
 HTTPParametersSet = {
     ? owner: Owner
-
     ~HTTPParameters
-
     ; qlog-specific
     ; indicates whether this implementation waits for a SETTINGS
     ; frame before processing requests
@@ -204,7 +202,6 @@ HTTPParameters = {
     ? max_header_list_size: uint64
     ? max_table_capacity: uint64
     ? blocked_streams_count: uint64
-
     ; additional settings for grease and extensions
     * text => uint64
 }
@@ -230,9 +227,7 @@ Definition:
 
 ~~~ cddl
 HTTPParametersRestored = {
-
     ~HTTPParameters
-
 }
 ~~~
 {: #http-parametersrestored-def title="HTTPParametersRestored definition"}
@@ -257,12 +252,9 @@ Definition:
 HTTPStreamTypeSet = {
     ? owner: Owner
     stream_id: uint64
-
     stream_type: HTTPStreamType
-
     ; only when stream_type === "unknown"
     ? raw_stream_type: uint64
-
     ; only when stream_type === "push"
     ? associated_push_id: uint64
 }
@@ -343,11 +335,9 @@ Definition:
 ~~~ cddl
 HTTPPushResolved = {
     ? push_id: uint64
-
     ; in case this is logged from a place that does not have access
     ; to the push_id
     ? stream_id: uint64
-
     decision: HTTPPushDecision
 }
 
@@ -384,7 +374,6 @@ Definition:
 QPACKStateUpdate = {
     owner: Owner
     ? dynamic_table_capacity: uint64
-
     ; effective current size, sum of all the entries
     ? dynamic_table_size: uint64
     ? known_received_count: uint64
@@ -428,7 +417,6 @@ QPACKDynamicTableUpdate = {
     ; local = the encoder's dynamic table
     ; remote = the decoder's dynamic table
     owner: Owner
-
     update_type: QPACKDynamicTableUpdateType
     entries: [+ QPACKDynamicTableEntry]
 }
@@ -458,10 +446,8 @@ Definition:
 QPACKHeadersEncoded = {
     ? stream_id: uint64
     ? headers: [+ HTTPField]
-
     block_prefix: QPACKHeaderBlockPrefix
     header_block: [+ QPACKHeaderBlockRepresentation]
-
     ? length: uint
     ? raw: hexstring
 }
@@ -483,10 +469,8 @@ Definition:
 QPACKHeadersDecoded = {
     ? stream_id: uint64
     ? headers: [+ HTTPField]
-
     block_prefix: QPACKHeaderBlockPrefix
     header_block: [+ QPACKHeaderBlockRepresentation]
-
     ? length: uint32
     ? raw: hexstring
 }
@@ -526,7 +510,6 @@ Definition:
 QPACKInstructionParsed = {
     ; see QPACKInstruction definition in appendix
     instruction: QPACKInstruction
-
     ? length: uint32
     ? raw: hexstring
 }
@@ -554,9 +537,12 @@ We extend the `$ProtocolEventBody` extension point defined in
 {{QLOG-MAIN}} with the HTTP/3 protocol events defined in this document.
 
 ~~~ cddl
-HTTPEvents = HTTPParametersSet / HTTPParametersRestored /
-             HTTPStreamTypeSet / HTTPFrameCreated /
-             HTTPFrameParsed / HTTPPushResolved
+HTTPEvents = HTTPParametersSet /
+             HTTPParametersRestored /
+             HTTPStreamTypeSet /
+             HTTPFrameCreated /
+             HTTPFrameParsed /
+             HTTPPushResolved
 
 $ProtocolEventBody /= HTTPEvents
 ~~~
@@ -680,7 +666,6 @@ HTTPPushPromiseFrame = {
 ~~~ cddl
 HTTPGoawayFrame = {
     frame_type: "goaway"
-
     ; Either stream_id or push_id.
     ; This is implicit from the sender of the frame
     id: uint64
@@ -703,7 +688,6 @@ HTTPMaxPushIDFrame = {
 ~~~ cddl
 HTTPReservedFrame = {
     frame_type: "reserved"
-
     ? length: uint64
 }
 ~~~
@@ -715,7 +699,6 @@ HTTPReservedFrame = {
 HTTPUnknownFrame = {
     frame_type: "unknown"
     raw_frame_type: uint64
-
     ? raw_length: uint32
     ? raw: hexstring
 }
@@ -762,9 +745,12 @@ We extend the `$ProtocolEventBody` extension point defined in
 {{QLOG-MAIN}} with the QPACK protocol events defined in this document.
 
 ~~~ cddl
-QPACKEvents = QPACKStateUpdate / QPACKStreamStateUpdate /
-              QPACKDynamicTableUpdate / QPACKHeadersEncoded /
-              QPACKHeadersDecoded / QPACKInstructionCreated /
+QPACKEvents = QPACKStateUpdate /
+              QPACKStreamStateUpdate /
+              QPACKDynamicTableUpdate /
+              QPACKHeadersEncoded /
+              QPACKHeadersDecoded /
+              QPACKInstructionCreated /
               QPACKInstructionParsed
 
 $ProtocolEventBody /= QPACKEvents
@@ -891,11 +877,9 @@ Note: also used for "indexed header field with post-base index"
 ~~~ cddl
 IndexedHeaderField = {
     header_field_type: "indexed_header"
-
     ; MUST be "dynamic" if is_post_base is true
     table_type: QPACKTableType
     index: uint32
-
     ; to represent the "indexed header field with post-base index"
     ; header field type
     is_post_base: bool .default false
@@ -910,17 +894,14 @@ Note: also used for "Literal header field with post-base name reference"
 ~~~ cddl
 LiteralHeaderFieldWithName = {
     header_field_type: "literal_with_name"
-
     ; the 3rd "N" bit
     preserve_literal: bool
-
     ; MUST be "dynamic" if is_post_base is true
     table_type: QPACKTableType
     name_index: uint32
     huffman_encoded_value: bool
     ? value_length: uint32
     ? value: text
-
     ; to represent the "indexed header field with post-base index"
     ; header field type
     is_post_base: bool .default false
@@ -934,13 +915,11 @@ title="LiteralHeaderFieldWithName definition"}
 ~~~ cddl
 LiteralHeaderFieldWithoutName = {
     header_field_type: "literal_without_name"
-
     ; the 3rd "N" bit
     preserve_literal: bool
     huffman_encoded_name: bool
     ? name_length: uint32
     ? name: text
-
     huffman_encoded_value: bool
     ? value_length: uint32
     ? value: text

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -192,6 +192,7 @@ Definition:
 HTTPParametersSet = {
     ? owner: Owner
     ~HTTPParameters
+
     ; qlog-specific
     ; indicates whether this implementation waits for a SETTINGS
     ; frame before processing requests
@@ -202,6 +203,7 @@ HTTPParameters = {
     ? max_header_list_size: uint64
     ? max_table_capacity: uint64
     ? blocked_streams_count: uint64
+
     ; additional settings for grease and extensions
     * text => uint64
 }
@@ -253,8 +255,10 @@ HTTPStreamTypeSet = {
     ? owner: Owner
     stream_id: uint64
     stream_type: HTTPStreamType
+
     ; only when stream_type === "unknown"
     ? raw_stream_type: uint64
+
     ; only when stream_type === "push"
     ? associated_push_id: uint64
 }
@@ -335,13 +339,15 @@ Definition:
 ~~~ cddl
 HTTPPushResolved = {
     ? push_id: uint64
+
     ; in case this is logged from a place that does not have access
     ; to the push_id
     ? stream_id: uint64
     decision: HTTPPushDecision
 }
 
-HTTPPushDecision = "claimed" / "abandoned"
+HTTPPushDecision = "claimed" / 
+                   "abandoned"
 ~~~
 {: #http-pushresolved-def title="HTTPPushResolved definition"}
 
@@ -374,6 +380,7 @@ Definition:
 QPACKStateUpdate = {
     owner: Owner
     ? dynamic_table_capacity: uint64
+
     ; effective current size, sum of all the entries
     ? dynamic_table_size: uint64
     ? known_received_count: uint64
@@ -396,12 +403,14 @@ Definition:
 ~~~ cddl
 QPACKStreamStateUpdate = {
     stream_id: uint64
+
     ; streams are assumed to start "unblocked"
     ; until they become "blocked"
     state: QPACKStreamState
 }
 
-QPACKStreamState = "blocked" / "unblocked"
+QPACKStreamState = "blocked" / 
+                   "unblocked"
 ~~~
 {: #qpack-streamstateupdate-def title="QPACKStreamStateUpdate definition"}
 
@@ -421,12 +430,15 @@ QPACKDynamicTableUpdate = {
     entries: [+ QPACKDynamicTableEntry]
 }
 
-QPACKDynamicTableUpdateType = "inserted" / "evicted"
+QPACKDynamicTableUpdateType = "inserted" /
+                              "evicted"
 
 QPACKDynamicTableEntry = {
     index: uint64
-    ? name: text / hexstring
-    ? value: text / hexstring
+    ? name: text /
+            hexstring
+    ? value: text /
+             hexstring
 }
 ~~~
 {: #qpack-dynamictableupdate-def title="QPACKDynamicTableUpdate definition"}
@@ -552,7 +564,8 @@ extension"}
 ## Owner
 
 ~~~ cddl
-Owner = "local" / "remote"
+Owner = "local" /
+        "remote"
 ~~~
 {: #owner-def title="Owner definition"}
 
@@ -666,6 +679,7 @@ HTTPPushPromiseFrame = {
 ~~~ cddl
 HTTPGoawayFrame = {
     frame_type: "goaway"
+
     ; Either stream_id or push_id.
     ; This is implicit from the sender of the frame
     id: uint64
@@ -877,9 +891,11 @@ Note: also used for "indexed header field with post-base index"
 ~~~ cddl
 IndexedHeaderField = {
     header_field_type: "indexed_header"
+
     ; MUST be "dynamic" if is_post_base is true
     table_type: QPACKTableType
     index: uint32
+
     ; to represent the "indexed header field with post-base index"
     ; header field type
     is_post_base: bool .default false
@@ -894,14 +910,17 @@ Note: also used for "Literal header field with post-base name reference"
 ~~~ cddl
 LiteralHeaderFieldWithName = {
     header_field_type: "literal_with_name"
+
     ; the 3rd "N" bit
     preserve_literal: bool
+
     ; MUST be "dynamic" if is_post_base is true
     table_type: QPACKTableType
     name_index: uint32
     huffman_encoded_value: bool
     ? value_length: uint32
     ? value: text
+
     ; to represent the "indexed header field with post-base index"
     ; header field type
     is_post_base: bool .default false
@@ -915,6 +934,7 @@ title="LiteralHeaderFieldWithName definition"}
 ~~~ cddl
 LiteralHeaderFieldWithoutName = {
     header_field_type: "literal_without_name"
+
     ; the 3rd "N" bit
     preserve_literal: bool
     huffman_encoded_name: bool
@@ -944,7 +964,8 @@ title="QPACKHeaderBlockPrefix definition"}
 ### QPACKTableType
 
 ~~~ cddl
-QPACKTableType = "static" / "dynamic"
+QPACKTableType = "static" /
+                 "dynamic"
 ~~~
 {: #qpacktabletype-def title="QPACKTableType definition"}
 

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -346,7 +346,7 @@ HTTPPushResolved = {
     decision: HTTPPushDecision
 }
 
-HTTPPushDecision = "claimed" / 
+HTTPPushDecision = "claimed" /
                    "abandoned"
 ~~~
 {: #http-pushresolved-def title="HTTPPushResolved definition"}
@@ -409,7 +409,7 @@ QPACKStreamStateUpdate = {
     state: QPACKStreamState
 }
 
-QPACKStreamState = "blocked" / 
+QPACKStreamState = "blocked" /
                    "unblocked"
 ~~~
 {: #qpack-streamstateupdate-def title="QPACKStreamStateUpdate definition"}

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -216,7 +216,8 @@ QlogFile = {
     ? title: text
     ? description: text
     ? summary: Summary
-    ? traces: [+ Trace / TraceError]
+    ? traces: [+ Trace /
+                 TraceError]
 }
 ~~~
 {: #qlog-file-def title="QlogFile definition"}
@@ -255,6 +256,7 @@ Definition:
 
 ~~~ cddl
 Summary = {
+
     ; summary can contain any type of custom information
     ; text here doesn't mean the type text,
     ; but the fact that keys/names in the objects are strings
@@ -305,6 +307,7 @@ Definition:
 ~~~ cddl
 TraceError = {
     error_description: text
+
     ; the original URI at which we attempted to find the file
     ? uri: text
     ? vantage_point: VantagePoint
@@ -395,6 +398,7 @@ Definition:
 
 ~~~ cddl
 Configuration = {
+
     ; time_offset is in milliseconds
     time_offset: float64
     original_uris:[* text]
@@ -480,7 +484,10 @@ VantagePoint = {
 ; client = endpoint which initiates the connection
 ; server = endpoint which accepts the connection
 ; network = observer in between client and server
-VantagePointType = "client" / "server" / "network" / "unknown"
+VantagePointType = "client" /
+                   "server" /
+                   "network" /
+                   "unknown"
 ~~~
 {: #vantage-point-def title="VantagePoint definition"}
 
@@ -555,9 +562,7 @@ Event = {
     time: float64
     name: text
     data: $ProtocolEventBody
-
     ? time_format: TimeFormat
-
     ? protocol_type: ProtocolType
     ? group_id: GroupID
 
@@ -598,7 +603,9 @@ is indicated in the "time_format" field, which allows one of three values:
 Definition:
 
 ~~~ cddl
-TimeFormat = "absolute" / "delta" / "relative"
+TimeFormat = "absolute" /
+             "delta" /
+             "relative"
 ~~~
 {: #time-format-def title="TimeFormat definition"}
 
@@ -716,8 +723,12 @@ $ProtocolEventBody /= {
     ? trigger: text
     * text => any
 }
+
 ; event documents are intended to extend this socket by using:
-; NewProtocolEvents = EventType1 / EventType2 / ... / EventTypeN
+; NewProtocolEvents = EventType1 /
+                      EventType2 /
+                      ... /
+                      EventTypeN
 ; $ProtocolEventBody /= NewProtocolEvents
 ~~~
 {: #data-def title="ProtocolEventBody definition"}
@@ -730,7 +741,9 @@ TransportPacketSent = {
     ? packet_size: uint16
     header: PacketHeader
     ? frames:[* QuicFrame]
-    ? trigger: "pto_probe" / "retransmit_timeout" / "bandwidth_probe"
+    ? trigger: "pto_probe" /
+               "retransmit_timeout" /
+               "bandwidth_probe"
 }
 
 could be serialized as
@@ -804,8 +817,10 @@ TransportPacketDropped = {
     ? packet_type: PacketType
     ? raw_length: uint16
 
-    ? trigger: "key_unavailable" / "unknown_connection_id" /
-               "decrypt_error" / "unsupported_version"
+    ? trigger: "key_unavailable" /
+               "unknown_connection_id" /
+               "decrypt_error" /
+               "unsupported_version"
 }
 ~~~~~~~~
 {: #trigger-ex title="Trigger example"}
@@ -958,10 +973,8 @@ Definition:
 CommonFields = {
     ? time_format: TimeFormat
     ? reference_time: float64
-
     ? protocol_type: ProtocolType
     ? group_id: GroupID
-
     * text => any
 }
 ~~~
@@ -1092,6 +1105,7 @@ Definition:
 
 ~~~ cddl
 RawInfo = {
+
     ; the full byte length of the entity (e.g., packet or frame),
     ; including headers and trailers
     ? length: uint64
@@ -1355,7 +1369,8 @@ original and (web-based) tools should take into account that a uint64
 field can be either a number or string.
 
 ~~~
-uint64 = text / uint .size 8
+uint64 = text /
+         uint .size 8
 ~~~
 {: #cddl-ijson-uint64-def title="Custom uint64 definition for I-JSON"}
 
@@ -1471,7 +1486,6 @@ Definition:
 ~~~ cddl
 QlogFileSeq = {
     qlog_format: "JSON-SEQ"
-
     qlog_version: text
     ? title: text
     ? description: text

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -256,7 +256,6 @@ ConnectivityConnectionStarted = {
     ? protocol: text .default "QUIC"
     ? src_port: uint16
     ? dst_port: uint16
-
     ? src_cid: ConnectionID
     ? dst_cid: ConnectionID
 }
@@ -288,13 +287,15 @@ Definition:
 
 ~~~ cddl
 ConnectivityConnectionClosed = {
+
     ; which side closed the connection
     ? owner: Owner
-
-    ? connection_code: TransportError / CryptoError / uint32
-    ? application_code: $ApplicationError / uint32
+    ? connection_code: TransportError /
+                       CryptoError /
+                       uint32
+    ? application_code: $ApplicationError /
+                        uint32
     ? internal_code: uint32
-
     ? reason: text
     ? trigger:
         "clean" /
@@ -329,7 +330,6 @@ Definition:
 ~~~ cddl
 ConnectivityConnectionIDUpdated = {
     owner: Owner
-
     ? old: ConnectionID
     ? new: ConnectionID
 }
@@ -369,8 +369,10 @@ Definition:
 
 ~~~ cddl
 ConnectivityConnectionStateUpdated = {
-    ? old: ConnectionState / SimpleConnectionState
-    new: ConnectionState / SimpleConnectionState
+    ? old: ConnectionState /
+           SimpleConnectionState
+    new: ConnectionState /
+         SimpleConnectionState
 }
 
 ConnectionState =
@@ -597,24 +599,20 @@ TransportParametersSet = {
     ? ack_delay_exponent: uint16
     ? max_ack_delay: uint16
     ? active_connection_id_limit: uint32
-
     ? initial_max_data: uint64
     ? initial_max_stream_data_bidi_local: uint64
     ? initial_max_stream_data_bidi_remote: uint64
     ? initial_max_stream_data_uni: uint64
     ? initial_max_streams_bidi: uint64
     ? initial_max_streams_uni: uint64
-
     ? preferred_address: PreferredAddress
 }
 
 PreferredAddress = {
     ip_v4: IPAddress
     ip_v6: IPAddress
-
     port_v4: uint16
     port_v6: uint16
-
     connection_id: ConnectionID
     stateless_reset_token: StatelessResetToken
 }
@@ -640,11 +638,9 @@ Definition:
 ~~~ cddl
 TransportParametersRestored = {
     ? disable_active_migration: bool
-
     ? max_idle_timeout: uint64
     ? max_udp_payload_size: uint32
     ? active_connection_id_limit: uint32
-
     ? initial_max_data: uint64
     ? initial_max_stream_data_bidi_local: uint64
     ? initial_max_stream_data_bidi_remote: uint64,
@@ -669,7 +665,6 @@ TransportPacketSent = {
 
     ; see appendix for the QuicFrame definitions
     ? frames: [* QuicFrame]
-
     ? is_coalesced: bool .default false
 
     ; only if header.packet_type === "retry"
@@ -681,12 +676,9 @@ TransportPacketSent = {
 
     ; only if header.packet_type === "version_negotiation"
     ? supported_versions: [+ QuicVersion]
-
     ? raw: RawInfo
     ? datagram_id: uint32
-
     ? is_mtu_probe_packet: bool .default false
-
     ? trigger:
       ; draft-23 5.1.1
       "retransmit_reordered" /
@@ -720,7 +712,6 @@ TransportPacketReceived = {
 
     ; see appendix for the definitions
     ? frames: [* QuicFrame]
-
     ? is_coalesced: bool .default false
 
     ; only if header.packet_type === "retry"
@@ -732,13 +723,10 @@ TransportPacketReceived = {
 
     ; only if header.packet_type === "version_negotiation"
     ? supported_versions: [+ QuicVersion]
-
     ? raw: RawInfo
     ? datagram_id: uint32
-
     ? trigger:
-        ; if packet was buffered because
-        ; it couldn't be decrypted before
+        ; if packet was buffered because it couldn't be decrypted before
         "keys_available"
 }
 ~~~
@@ -759,13 +747,12 @@ Definition:
 
 ~~~ cddl
 TransportPacketDropped = {
+
     ; primarily packet_type should be filled here,
     ; as other fields might not be parseable
     ? header: PacketHeader
-
     ? raw: RawInfo
     ? datagram_id: uint32
-
     ? trigger:
         "key_unavailable" /
         "unknown_connection_id" /
@@ -804,10 +791,8 @@ TransportPacketBuffered = {
     ; primarily packet_type and possible packet_number should be
     ; filled here as other elements might not be available yet
     ? header: PacketHeader
-
     ? raw: RawInfo
     ? datagram_id: uint32
-
     ? trigger:
         ; indicates the parser cannot keep up, temporarily buffers
         ; packet for later processing
@@ -837,7 +822,6 @@ Definition:
 ~~~ cddl
 TransportPacketsAcked = {
     ? packet_number_space: PacketNumberSpace
-
     ? packet_numbers: [+ uint64]
 }
 ~~~
@@ -857,13 +841,13 @@ Definition:
 
 ~~~ cddl
 TransportDatagramsSent = {
+
     ; to support passing multiple at once
     ? count: uint16
 
     ; RawInfo:length field indicates total length of the datagrams
     ; including UDP header length
     ? raw: [+ RawInfo]
-
     ? datagram_ids: [+ uint32]
 }
 ~~~
@@ -888,13 +872,13 @@ Definition:
 
 ~~~ cddl
 TransportDatagramsReceived = {
+
     ; to support passing multiple at once
     ? count: uint16
 
     ; RawInfo:length field indicates total length of the datagrams
     ; including UDP header length
     ? raw: [+ RawInfo]
-
     ? datagram_ids: [+ uint32]
 }
 ~~~
@@ -928,18 +912,18 @@ signals for these state changes.
 Definition:
 
 ~~~ cddl
-StreamType = "unidirectional" / "bidirectional"
+StreamType = "unidirectional" /
+             "bidirectional"
 
 TransportStreamStateUpdated = {
     stream_id: uint64
 
     ; mainly useful when opening the stream
     ? stream_type: StreamType
-
     ? old: StreamState
     new: StreamState
-
-    ? stream_side: "sending" / "receiving"
+    ? stream_side: "sending" /
+    "receiving"
 }
 
 StreamState =
@@ -949,23 +933,19 @@ StreamState =
     "half_closed_local" /
     "half_closed_remote" /
     "closed" /
-
     ; sending-side stream states, draft-23 3.1.
     "ready" /
     "send" /
     "data_sent" /
     "reset_sent" /
     "reset_received" /
-
     ; receive-side stream states, draft-23 3.2.
     "receive" /
     "size_known" /
     "data_read" /
     "reset_read" /
-
     ; both-side states
     "data_received" /
-
     ; qlog-defined:
     ; memory actually freed
     "destroyed"
@@ -1013,9 +993,9 @@ Definition:
 
 ~~~ cddl
 TransportFramesProcessed = {
+
     ; see appendix for the QuicFrame definitions
     frames: [* QuicFrame]
-
     ? packet_number: uint64
 }
 ~~~
@@ -1046,9 +1026,16 @@ TransportDataMoved = {
 
     ; byte length of the moved data
     ? length: uint64
-
-    ? from: "user" / "application" / "transport" / "network" / text
-    ? to: "user" / "application" / "transport" / "network" / text
+    ? from: "user" /
+            "application" /
+            "transport" /
+            "network" /
+            text
+    ? to: "user" /
+          "application" /
+          "transport" /
+          "network" /
+          text
 
     ; raw bytes that were transferred
     ? data: hexstring
@@ -1082,13 +1069,11 @@ Definition:
 ~~~ cddl
 SecurityKeyUpdated = {
     key_type: KeyType
-
     ? old: hexstring
     new: hexstring
 
     ; needed for 1RTT key updates
     ? generation: uint32
-
     ? trigger:
         ; (e.g., initial, handshake and 0-RTT keys
         ; are generated by TLS)
@@ -1112,7 +1097,6 @@ SecurityKeyDiscarded = {
 
     ; needed for 1RTT key updates
     ? generation: uint32
-
     ? trigger:
         ; (e.g., initial, handshake and 0-RTT keys
         ; are generated by TLS)
@@ -1142,6 +1126,7 @@ Definition:
 
 ~~~ cddl
 RecoveryParametersSet = {
+
     ; Loss detection, see recovery draft-23, Appendix A.2
     ; in amount of packets
     ? reordering_threshold: uint16
@@ -1190,13 +1175,13 @@ Definition:
 
 ~~~ cddl
 RecoveryMetricsUpdated = {
+
     ; Loss detection, see recovery draft-23, Appendix A.3
     ; all following rtt fields are expressed in ms
     ? min_rtt: float32
     ? smoothed_rtt: float32
     ? latest_rtt: float32
     ? rtt_variance: float32
-
     ? pto_count: uint16
 
     ; Congestion control, Appendix B.2.
@@ -1244,7 +1229,6 @@ Definition:
 RecoveryCongestionStateUpdated = {
     ? old: text
     new: text
-
     ? trigger:
         "persistent_congestion" /
         "ECN"
@@ -1273,11 +1257,14 @@ Definition:
 
 ~~~ cddl
 RecoveryLossTimerUpdated = {
-    ; called "mode" in draft-23 A.9.
-    ? timer_type: "ack" / "pto"
-    ? packet_number_space: PacketNumberSpace
 
-    event_type: "set" / "expired" / "cancelled"
+    ; called "mode" in draft-23 A.9.
+    ? timer_type: "ack" /
+                  "pto"
+    ? packet_number_space: PacketNumberSpace
+    event_type: "set" /
+                "expired" /
+                "cancelled"
 
     ; if event_type === "set": delta time is in ms from
     ; this event's timestamp until when the timer will trigger
@@ -1300,6 +1287,7 @@ Definition:
 
 ~~~ cddl
 RecoveryPacketLost = {
+
     ; should include at least the packet_type and packet_number
     ? header: PacketHeader
 
@@ -1307,9 +1295,7 @@ RecoveryPacketLost = {
     ; packets, so these are optional
     ; see appendix for the QuicFrame definitions
     ? frames: [* QuicFrame]
-
     ? is_mtu_probe_packet: bool .default false
-
     ? trigger:
         "reordering_threshold" /
         "time_threshold" /
@@ -1348,6 +1334,7 @@ Definition:
 
 ~~~ cddl
 RecoveryMarkedForRetransmit = {
+
     ; see appendix for the QuicFrame definitions
     frames: [+ QuicFrame]
 }
@@ -1379,16 +1366,25 @@ QuicEvents = ConnectivityServerListening /
              ConnectivitySpinBitUpdated /
              ConnectivityConnectionStateUpdated /
              ConnectivityMTUUpdated /
-             SecurityKeyUpdated / SecurityKeyDiscarded /
-             TransportVersionInformation / TransportALPNInformation /
-             TransportParametersSet / TransportParametersRestored /
-             TransportPacketSent / TransportPacketReceived /
-             TransportPacketDropped / TransportPacketBuffered /
-             TransportPacketsAcked / TransportDatagramsSent /
-             TransportDatagramsReceived / TransportDatagramDropped /
-             TransportStreamStateUpdated / TransportFramesProcessed /
+             SecurityKeyUpdated /
+             SecurityKeyDiscarded /
+             TransportVersionInformation /
+             TransportALPNInformation /
+             TransportParametersSet /
+             TransportParametersRestored /
+             TransportPacketSent /
+             TransportPacketReceived /
+             TransportPacketDropped /
+             TransportPacketBuffered /
+             TransportPacketsAcked /
+             TransportDatagramsSent /
+             TransportDatagramsReceived /
+             TransportDatagramDropped /
+             TransportStreamStateUpdated /
+             TransportFramesProcessed /
              TransportDataMoved /
-             RecoveryParametersSet / RecoveryMetricsUpdated /
+             RecoveryParametersSet /
+             RecoveryMetricsUpdated /
              RecoveryCongestionStateUpdated /
              RecoveryLossTimerUpdated /
              RecoveryPacketLost
@@ -1413,7 +1409,8 @@ ConnectionID = hexstring
 ## Owner
 
 ~~~ cddl
-Owner = "local" / "remote"
+Owner = "local" /
+        "remote"
 ~~~
 {: #owner-def title="Owner definition"}
 
@@ -1424,27 +1421,37 @@ Owner = "local" / "remote"
 ; (e.g., "127.0.0.1" for v4 or
 ; "2001:0db8:85a3:0000:0000:8a2e:0370:7334" for v6) or
 ; use a raw byte-form (as the string forms can be ambiguous)
-IPAddress = text / hexstring
+IPAddress = text /
+            hexstring
 ~~~
 {: #ipaddress-def title="IPAddress definition"}
 
 ~~~ cddl
-IPVersion = "v4" / "v6"
+IPVersion = "v4" /
+            "v6"
 ~~~
 {: #ipversion-def title="IPVersion definition"}
 
 ## PacketType
 
 ~~~ cddl
-PacketType = "initial" / "handshake" / "0RTT" / "1RTT" / "retry" /
-    "version_negotiation" / "stateless_reset" / "unknown"
+PacketType = "initial" /
+             "handshake" /
+             "0RTT" /
+             "1RTT" /
+             "retry" /
+             "version_negotiation" /
+             "stateless_reset" /
+             "unknown"
 ~~~
 {: #packettype-def title="PacketType definition"}
 
 ## PacketNumberSpace
 
 ~~~ cddl
-PacketNumberSpace = "initial" / "handshake" / "application_data"
+PacketNumberSpace = "initial" /
+                    "handshake" /
+                    "application_data"
 ~~~
 {: #packetnumberspace-def title="PacketNumberSpace definition"}
 
@@ -1453,6 +1460,7 @@ PacketNumberSpace = "initial" / "handshake" / "application_data"
 ~~~ cddl
 PacketHeader = {
     packet_type: PacketType
+
     ; only if packet_type === "initial" || "handshake" || "0RTT" ||
     ;                         "1RTT"
     ? packet_number: uint64
@@ -1485,7 +1493,8 @@ PacketHeader = {
 
 ~~~ cddl
 Token = {
-    ? type: "retry" / "resumption"
+    ? type: "retry" /
+            "resumption"
 
     ; byte length of the token
     ? length: uint32
@@ -1522,25 +1531,41 @@ parameters and in NEW_CONNECTION_ID frames.
 ## KeyType
 
 ~~~ cddl
-KeyType =
-    "server_initial_secret" / "client_initial_secret" /
-    "server_handshake_secret" / "client_handshake_secret" /
-    "server_0rtt_secret" / "client_0rtt_secret" /
-    "server_1rtt_secret" / "client_1rtt_secret"
+KeyType = "server_initial_secret" /
+          "client_initial_secret" /
+          "server_handshake_secret" /
+          "client_handshake_secret" /
+          "server_0rtt_secret" /
+          "client_0rtt_secret" /
+          "server_1rtt_secret" /
+          "client_1rtt_secret"
 ~~~
 {: #keytype-def title="KeyType definition"}
 
 ## QUIC Frames
 
 ~~~ cddl
-QuicFrame =
-  PaddingFrame / PingFrame / AckFrame / ResetStreamFrame /
-  StopSendingFrame / CryptoFrame / NewTokenFrame / StreamFrame /
-  MaxDataFrame / MaxStreamDataFrame / MaxStreamsFrame /
-  DataBlockedFrame / StreamDataBlockedFrame / StreamsBlockedFrame /
-  NewConnectionIDFrame / RetireConnectionIDFrame /
-  PathChallengeFrame / PathResponseFrame / ConnectionCloseFrame /
-  HandshakeDoneFrame / UnknownFrame
+QuicFrame = PaddingFrame /
+            PingFrame /
+            AckFrame /
+            ResetStreamFrame /
+            StopSendingFrame /
+            CryptoFrame /
+            NewTokenFrame /
+            StreamFrame /
+            MaxDataFrame /
+            MaxStreamDataFrame /
+            MaxStreamsFrame /
+            DataBlockedFrame /
+            StreamDataBlockedFrame /
+            StreamsBlockedFrame /
+            NewConnectionIDFrame /
+            RetireConnectionIDFrame /
+            PathChallengeFrame /
+            PathResponseFrame /
+            ConnectionCloseFrame /
+            HandshakeDoneFrame /
+            UnknownFrame
 ~~~
 {: #quicframe-def title="QuicFrame definition"}
 
@@ -1621,9 +1646,9 @@ log \[120\] instead and tools MUST be able to deal with both notations.
 ~~~ cddl
 ResetStreamFrame = {
     frame_type: "reset_stream"
-
     stream_id: uint64
-    error_code: $ApplicationError / uint32
+    error_code: $ApplicationError /
+                uint32
 
     ; in bytes
     final_size: uint64
@@ -1640,9 +1665,9 @@ ResetStreamFrame = {
 ~~~ cddl
 StopSendingFrame = {
     frame_type: "stop_sending"
-
     stream_id: uint64
-    error_code: $ApplicationError / uint32
+    error_code: $ApplicationError /
+                uint32
 
     ; total frame length, including frame header
     ? length: uint32
@@ -1656,10 +1681,8 @@ StopSendingFrame = {
 ~~~ cddl
 CryptoFrame = {
     frame_type: "crypto"
-
     offset: uint64
     length: uint64
-
     ? payload_length: uint32
 }
 ~~~
@@ -1670,7 +1693,6 @@ CryptoFrame = {
 ~~~ cddl
 NewTokenFrame = {
   frame_type: "new_token"
-
   token: Token
 }
 ~~~
@@ -1681,7 +1703,6 @@ NewTokenFrame = {
 ~~~ cddl
 StreamFrame = {
     frame_type: "stream"
-
     stream_id: uint64
 
     ; These two MUST always be set
@@ -1693,7 +1714,6 @@ StreamFrame = {
     ; but MUST only be set if the value is true
     ; if absent, the value MUST be assumed to be false
     ? fin: bool .default false
-
     ? raw: hexstring
 }
 ~~~
@@ -1704,7 +1724,6 @@ StreamFrame = {
 ~~~ cddl
 MaxDataFrame = {
   frame_type: "max_data"
-
   maximum: uint64
 }
 ~~~
@@ -1715,7 +1734,6 @@ MaxDataFrame = {
 ~~~ cddl
 MaxStreamDataFrame = {
   frame_type: "max_stream_data"
-
   stream_id: uint64
   maximum: uint64
 }
@@ -1727,7 +1745,6 @@ MaxStreamDataFrame = {
 ~~~ cddl
 MaxStreamsFrame = {
   frame_type: "max_streams"
-
   stream_type: StreamType
   maximum: uint64
 }
@@ -1739,7 +1756,6 @@ MaxStreamsFrame = {
 ~~~ cddl
 DataBlockedFrame = {
   frame_type: "data_blocked"
-
   limit: uint64
 }
 ~~~
@@ -1750,7 +1766,6 @@ DataBlockedFrame = {
 ~~~ cddl
 StreamDataBlockedFrame = {
   frame_type: "stream_data_blocked"
-
   stream_id: uint64
   limit: uint64
 }
@@ -1762,7 +1777,6 @@ StreamDataBlockedFrame = {
 ~~~ cddl
 StreamsBlockedFrame = {
   frame_type: "streams_blocked"
-
   stream_type: StreamType
   limit: uint64
 }
@@ -1774,7 +1788,6 @@ StreamsBlockedFrame = {
 ~~~ cddl
 NewConnectionIDFrame = {
   frame_type: "new_connection_id"
-
   sequence_number: uint32
   retire_prior_to: uint32
 
@@ -1782,7 +1795,6 @@ NewConnectionIDFrame = {
   ; connection_id cannot be logged
   ? connection_id_length: uint8
   connection_id: ConnectionID
-
   ? stateless_reset_token: StatelessResetToken
 }
 ~~~
@@ -1793,7 +1805,6 @@ NewConnectionIDFrame = {
 ~~~ cddl
 RetireConnectionIDFrame = {
   frame_type: "retire_connection_id"
-
   sequence_number: uint32
 }
 ~~~
@@ -1829,19 +1840,23 @@ raw_error_code is the actual, numerical code. This is useful because some error
 types are spread out over a range of codes (e.g., QUIC's crypto_error).
 
 ~~~ cddl
-ErrorSpace = "transport" / "application"
+ErrorSpace = "transport" /
+             "application"
 
 ConnectionCloseFrame = {
     frame_type: "connection_close"
 
     ? error_space: ErrorSpace
-    ? error_code: TransportError / $ApplicationError / uint32
+    ? error_code: TransportError /
+                  $ApplicationError /
+                  uint32
     ? raw_error_code: uint32
     ? reason: text
 
     ; For known frame types, the appropriate "frame_type" string
     ; For unknown frame types, the hex encoded identifier value
-    ? trigger_frame_type: uint64 / text
+    ? trigger_frame_type: uint64 /
+                          text
 }
 ~~~
 {: #connectioncloseframe-def title="ConnectionCloseFrame definition"}
@@ -1861,7 +1876,6 @@ HandshakeDoneFrame = {
 UnknownFrame = {
     frame_type: "unknown"
     raw_frame_type: uint64
-
     ? raw_length: uint32
     ? raw: hexstring
 }
@@ -1871,13 +1885,20 @@ UnknownFrame = {
 ### TransportError
 
 ~~~ cddl
-TransportError = "no_error" / "internal_error" /
-    "connection_refused" / "flow_control_error" /
-    "stream_limit_error" / "stream_state_error" /
-    "final_size_error" / "frame_encoding_error" /
-    "transport_parameter_error" / "connection_id_limit_error" /
-    "protocol_violation" / "invalid_token" / "application_error" /
-    "crypto_buffer_exceeded"
+TransportError = "no_error" /
+                 "internal_error" /
+                 "connection_refused" /
+                 "flow_control_error" /
+                 "stream_limit_error" /
+                 "stream_state_error" /
+                 "final_size_error" /
+                 "frame_encoding_error" /
+                 "transport_parameter_error" /
+                 "connection_id_limit_error" /
+                 "protocol_violation" /
+                 "invalid_token" /
+                 "application_error" /
+                 "crypto_buffer_exceeded"
 ~~~
 {: #transporterror-def title="TransportError definition"}
 
@@ -1890,7 +1911,8 @@ As such, we cannot define it here directly. Though we provide an extension point
 Application-level qlog definitions that wish to define new ApplicationError strings MUST do so by extending the $ApplicationError socket as such:
 
 ~~~
-$ApplicationError /= "new_error_name" / "another_new_error_name"
+$ApplicationError /= "new_error_name" /
+                     "another_new_error_name"
 ~~~
 
 ### CryptoError


### PR DESCRIPTION
in the H3 CDDL definitions we have been using extra lines to space things out, but it is a bit inconsistent. 
This PR tries to make things more consistent by
  * only keep empty lines between types in the same block
  * split unions into multiple lines, except for when only two types are present