### PR TITLE
Make QuicFrame and HTTPFrame into CDDL extension points

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -301,7 +301,7 @@ Definition:
 HTTPFrameCreated = {
     stream_id: uint64
     ? length: uint64
-    frame: HTTPFrame
+    frame: $HTTPFrame
     ? raw: RawInfo
 }
 ~~~
@@ -328,7 +328,7 @@ Definition:
 HTTPFrameParsed = {
     stream_id: uint64
     ? length: uint64
-    frame: HTTPFrame
+    frame: $HTTPFrame
     ? raw: RawInfo
 }
 ~~~
@@ -378,8 +378,23 @@ Owner = "local" / "remote"
 
 ## HTTPFrame
 
+The generic `$HTTPFrame` is defined here as a CDDL extension point (a "socket"
+or "plug"). This allows other documents to extend this extension point when
+defining new HTTP/3 protocol frame types to enable automated validation of
+aggregated qlog schemas.
+
 ~~~ cddl
-HTTPFrame =  HTTPDataFrame /
+; The HTTPFrame is any key-value map (e.g., JSON object)
+$HTTPFrame /= {
+    * text => any
+}
+~~~
+{: #httpframe-def title="HTTPFrame plug definition"}
+
+The HTTP/3 frame types defined in this document are as follows:
+
+~~~ cddl
+HTTPBaseFrames =  HTTPDataFrame /
              HTTPHeadersFrame /
              HTTPCancelPushFrame /
              HTTPSettingsFrame /
@@ -388,8 +403,10 @@ HTTPFrame =  HTTPDataFrame /
              HTTPMaxPushIDFrame /
              HTTPReservedFrame /
              HTTPUnknownFrame
+
+$HTTPFrame /= HTTPBaseFrames
 ~~~
-{: #httpframe-def title="HTTPFrame definition"}
+{: #httpbaseframe-def title="HTTPFrames defined in this document"}
 
 ### HTTPDataFrame
 ~~~ cddl

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -720,7 +720,7 @@ $ProtocolEventBody /= {
 ; NewProtocolEvents = EventType1 / EventType2 / ... / EventTypeN
 ; $ProtocolEventBody /= NewProtocolEvents
 ~~~
-{: #data-def title="ProtocolEventBody definition"}
+{: #protocoleventbody-def title="ProtocolEventBody definition"}
 
 One purely illustrative example for a QUIC "packet_sent" event is shown in
 {{data-ex}}:

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -697,8 +697,7 @@ Definition:
 TransportPacketSent = {
     header: PacketHeader
 
-    ; see appendix for the QuicFrame definitions
-    ? frames: [* QuicFrame]
+    ? frames: [* $QuicFrame]
 
     ? is_coalesced: bool .default false
 
@@ -748,8 +747,7 @@ Definition:
 TransportPacketReceived = {
     header: PacketHeader
 
-    ; see appendix for the definitions
-    ? frames: [* QuicFrame]
+    ? frames: [* $QuicFrame]
 
     ? is_coalesced: bool .default false
 
@@ -1043,8 +1041,7 @@ Definition:
 
 ~~~ cddl
 TransportFramesProcessed = {
-    ; see appendix for the QuicFrame definitions
-    frames: [* QuicFrame]
+    frames: [* $QuicFrame]
 
     ? packet_number: uint64
 }
@@ -1335,8 +1332,7 @@ RecoveryPacketLost = {
 
     ; not all implementations will keep track of full
     ; packets, so these are optional
-    ; see appendix for the QuicFrame definitions
-    ? frames: [* QuicFrame]
+    ? frames: [* $QuicFrame]
 
     ? is_mtu_probe_packet: bool .default false
 
@@ -1378,8 +1374,7 @@ Definition:
 
 ~~~ cddl
 RecoveryMarkedForRetransmit = {
-    ; see appendix for the QuicFrame definitions
-    frames: [+ QuicFrame]
+    frames: [+ $QuicFrame]
 }
 ~~~
 {: #recovery-markedforretransmit-def title="RecoveryMarkedForRetransmit definition"}
@@ -1522,8 +1517,23 @@ KeyType =
 
 ## QUIC Frames
 
+The generic `$QuicFrame` is defined here as a CDDL extension point (a "socket"
+or "plug"). This allows other documents to extend this extension point when
+defining new QUIC protocol frame types to enable automated validation of
+aggregated qlog schemas.
+
 ~~~ cddl
-QuicFrame =
+; The QuicFrame is any key-value map (e.g., JSON object)
+$QuicFrame /= {
+    * text => any
+}
+~~~
+{: #quicframe-def title="QuicFrame plug definition"}
+
+The QUIC frame types defined in this document are as follows:
+
+~~~ cddl
+QuicBaseFrames /=
   PaddingFrame / PingFrame / AckFrame / ResetStreamFrame /
   StopSendingFrame / CryptoFrame / NewTokenFrame / StreamFrame /
   MaxDataFrame / MaxStreamDataFrame / MaxStreamsFrame /
@@ -1531,8 +1541,10 @@ QuicFrame =
   NewConnectionIDFrame / RetireConnectionIDFrame /
   PathChallengeFrame / PathResponseFrame / ConnectionCloseFrame /
   HandshakeDoneFrame / UnknownFrame
+
+$QuicFrame /= QuicBaseFrames
 ~~~
-{: #quicframe-def title="QuicFrame definition"}
+{: #quicbaseframe-def title="QuicFrames defined in this document"}
 
 ### PaddingFrame
 


### PR DESCRIPTION
In doing the exercise to try and define a new DATAGRAM extension for qlog (at https://github.com/rmarx/draft-marx-quic-qlog-datagram), it became clear that we only had a CDDL extension point for the events themselves (`$ProtocolEventBody`) but NOT for the individual QUIC and HTTP/3 frames.

This is needed so we can add the CDDL definitions for new frames in other documents and have them properly matched to the CDDL expectations of "main document" events like `http:frame_parsed` and `transport:packet_sent`.