### PR TITLE
can a hexstring field be empty ?

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -125,7 +125,7 @@ uint64 = uint .size 8
 ; examples: 82dc, 027339, 4cdbfd9bf0
 ; this is needed because the default CDDL binary string (bytes/bstr)
 ; is only CBOR and not JSON compatible
-hexstring = text .regexp "([0-9a-f]{2})*"
+hexstring = text .regexp "([0-9a-f]{2})+"
 ~~~
 {: #cddl-custom-types-def title="Additional CDDL type definitions"}
 


### PR DESCRIPTION
A zero-length connection id is the only use-cases I can find where an empty hexstring would make sense. But we are using an optional field for those?
This is a minor thing. Posting for discussion more than anything
