### PR TITLE
Script to validate CDDL for all documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ venv/
 lib
 draft-marx-quic-logging-main-schema.xml
 .travis.yml
+*.cddl
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ draft-marx-quic-logging-main-schema.xml
 .travis.yml
 *.cddl
 *.json
+*.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'cddl'

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ cddl: $(drafts_source)
 	    fi; \
 	done
 
+# override lib/main.mk deps target, to also install deps from Gemfile
+.PHONY: deps
+deps::
+		$(MAKE) -f $(LIBDIR)/main.mk $@
+		bundle install --gemfile=$(realpath $<)
+
 # override lib/main.mk clean target, to cleanup json and cddl files
 .PHONY: clean
 clean::

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ else
 endif
 
 # run cddl_validate.sh for all drafts_source files 
-cddl: $(drafts_source)
-	@for f in $^; do \
+cddl:
+	@for f in $(drafts_source); do \
 	    echo "Validating $$f"; \
 	    ./cddl_validate.sh $$f > /tmp/foo 2>&1 ; \
 	    if [ $$? -eq 0 ]; then \
@@ -34,4 +34,13 @@ deps::
 clean::
 		$(MAKE) -f $(LIBDIR)/main.mk $@
 		-rm -f \
-	    $(addsuffix -[0-9][0-9].{json$(COMMA)cddl},$(drafts))
+	    $(addsuffix -[0-9][0-9].{json$(COMMA)cddl},$(drafts)) \
+	    $(addsuffix .{json$(COMMA)cddl},$(drafts)) \
+			Gemfile.lock
+
+# override lib/main.mk deps target, to also install deps from Gemfile
+.PHONY: all
+all:: cddl
+		$(MAKE) -f $(LIBDIR)/main.mk $@
+
+

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,23 @@ else
 	git clone -q --depth 10 $(CLONE_ARGS) \
 	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
+
+# run cddl_validate.sh for all drafts_source files 
+cddl: $(drafts_source)
+	@for f in $^; do \
+	    echo "Validating $$f"; \
+	    ./cddl_validate.sh $$f > /tmp/foo 2>&1 ; \
+	    if [ $$? -eq 0 ]; then \
+	        echo "  OK"; \
+	    else \
+	        echo "  ERROR"; \
+					echo "  debug with: ./cddl_validate.sh $$f"; \
+	    fi; \
+	done
+
+# override lib/main.mk clean target, to cleanup json and cddl files
+.PHONY: clean
+clean::
+		$(MAKE) -f $(LIBDIR)/main.mk $@
+		-rm -f \
+	    $(addsuffix -[0-9][0-9].{json$(COMMA)cddl},$(drafts))

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,6 @@ cddl:
 	    fi; \
 	done
 
-# override lib/main.mk deps target, to also install deps from Gemfile
-.PHONY: deps
-deps::
-		$(MAKE) -f $(LIBDIR)/main.mk $@
-		bundle install --gemfile=$(realpath $<)
-
 # override lib/main.mk clean target, to cleanup json and cddl files
 .PHONY: clean
 clean::
@@ -38,9 +32,7 @@ clean::
 	    $(addsuffix .{json$(COMMA)cddl},$(drafts)) \
 			Gemfile.lock
 
-# override lib/main.mk deps target, to also install deps from Gemfile
+# override lib/main.mk all target, to also install deps from Gemfile
 .PHONY: all
 all:: cddl
 		$(MAKE) -f $(LIBDIR)/main.mk $@
-
-

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -17,7 +17,6 @@ CDDL_JSON_FILE="${BASE_FILENAME}.json"
 # $2: the output (.cddl) file
 function extract_cddl() {
     cat $1 | awk 'BEGIN{flag=0} /~~~ cddl/{flag=1; printf "\n"; next} /~~~/{flag=0; next} flag' >> $2
-    #sed -n '/^```cddl/,/^```/p' $1 | sed '1d;$d' >> $2
 }
 
 # Prepend an object with all the unused types to a CDDL file

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# requires `gem install cddl`
+#
+set -e
+set -o nounset
+
+INPUT_FILE="$1"
+BASE_FILENAME="${INPUT_FILE%.*}"
+CDDL_FILE="${BASE_FILENAME}.cddl"
+CDDL_JSON_FILE="${BASE_FILENAME}.json"
+
+:> $CDDL_FILE
+
+# Extracts CDDL from a markdown file
+# $1: the input (.md) file
+# $2: the output (.cddl) file
+function extract_cddl() {
+    cat $1 | awk 'BEGIN{flag=0} /~~~ cddl/{flag=1; printf "\n"; next} /~~~/{flag=0; next} flag' >> $2
+    #sed -n '/^```cddl/,/^```/p' $1 | sed '1d;$d' >> $2
+}
+
+# Prepend an object with all the unused types to a CDDL file
+# $1: the input (.cddl) file
+function generate_aux_object() {
+    # Generate the list of Unused types
+    unused_types=$(cddl $1 generate 2>&1 | grep Unused | cut -d " " -f 4)
+    # Create an object with all the unused types
+    tmpfile=$(mktemp)
+    echo "AuxObjectWithAllTypesForValidationOnly = {" >> $tmpfile
+    for type in ${unused_types}; do
+      lowercase_type=$(echo ${type} | tr '[:upper:]' '[:lower:]')
+      echo "    ${lowercase_type}_: ${type}" >> $tmpfile
+    done
+    echo -e "}\n" >> $tmpfile
+
+    tmpfile2=$(mktemp)
+    cat $tmpfile $1 > $tmpfile2
+    mv $tmpfile2 $1
+}
+
+if [ $INPUT_FILE != "draft-ietf-quic-qlog-main-schema.md" ]; then
+    # Extracts CDDL from the main schema file
+    extract_cddl draft-ietf-quic-qlog-main-schema.md $CDDL_FILE
+fi
+
+extract_cddl $INPUT_FILE $CDDL_FILE
+generate_aux_object $CDDL_FILE
+# The cddl command doesn't know how to work with .regexp with a give size.
+# We use that with hexstring sometimes, so clean that up
+sed -i '' "s/hexstring .size .*/hexstring/" $CDDL_FILE
+cddl ${CDDL_FILE} json-generate > ${CDDL_JSON_FILE}

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -46,7 +46,12 @@ fi
 
 extract_cddl $INPUT_FILE $CDDL_FILE
 generate_aux_object $CDDL_FILE
+
 # The cddl command doesn't know how to work with .regexp with a give size.
 # We use that with hexstring sometimes, so clean that up
-sed -i '' "s/hexstring .size .*/hexstring/" $CDDL_FILE
+tmpfile=$(mktemp)
+sed "s/hexstring .size .*/hexstring/" $CDDL_FILE > $tmpfile
+mv $tmpfile $CDDL_FILE
+
+# run the CDDL validator and generate the sample JSON file
 cddl ${CDDL_FILE} json-generate > ${CDDL_JSON_FILE}

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -481,7 +481,7 @@ For now, infer from other connectivity events and path_challenge/path_response f
 ## mtu_updated {#connectivity-mtuupdated}
 Importance: Extra
 
-~~~ ccdl
+~~~ cddl
 ConnectivityMTUUpdated = {
   ? old: uint16
   new: uint16


### PR DESCRIPTION
the main_schema file is validated on its own,
both the http and quic event documents also include the main schema

Sample run
```
~/github/qlog (main*) » make cddl                                                                                  lnicco@Lucas-MacBook-Air
Validating draft-ietf-quic-qlog-h3-events.md
  OK
Validating draft-ietf-quic-qlog-main-schema.md
  OK
Validating draft-ietf-quic-qlog-quic-events.md
  ERROR
  debug with: ./cddl_validate.sh draft-ietf-quic-qlog-quic-events.md
```

The quic events file error is fixed in #267
