### PR TITLE
Add addtional_schema field

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -107,9 +107,9 @@ When any event from this document is included in a qlog trace, the
 ## Usage with QUIC
 
 The events described in this document can be used with or without logging the
-related QUIC events defined in {{QLOG-QUIC}}. If used with QUIC events, the QUIC
-document takes precedence in terms of recommended filenames and trace separation
-setups.
+related QUIC events defined in {{QLOG-QUIC}} with "qlog_version" of "0.4". If
+used with QUIC events, the QUIC document takes precedence in terms of
+recommended filenames and trace separation setups.
 
 If used without QUIC events, it is recommended that the implementation assign a
 globally unique identifier to each HTTP/3 connection. This ID can then be used as

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -209,6 +209,14 @@ In order to make it easier to parse and identify qlog files and their
 serialization format, the "qlog_version" and "qlog_format" fields and their values
 SHOULD be in the first 256 characters/bytes of the resulting log file.
 
+A qlog Trace ({{trace}} can include Events. This document defines several
+generic events ({{generic-events-and-data-classes}}). Additional event
+definitions, e.g., protocol-specific events, can be defined in additional
+schema; see {{guidelines}}. The "additional_schema" field can be used to
+indicate the additional schema used for traces in a qlog file. It is RECOMMENDED
+that schema defined by the IETF are referenced by their case-insensitive
+document name e.g., "draft-ietf-quic-qlog-quic-events-03" or "rfcNNNN".
+
 An example of the qlog file's top-level structure is shown in {{qlog-file-def}}.
 
 Definition:
@@ -217,6 +225,7 @@ Definition:
 QlogFile = {
     qlog_version: text
     ? qlog_format: text .default "JSON"
+    ? additional_schema: [+ text]
     ? title: text
     ? description: text
     ? traces: [+ Trace /
@@ -231,6 +240,10 @@ JSON serialization example:
 {
     "qlog_version": "0.4",
     "qlog_format": "JSON",
+    "additional_schema": [
+      "draft-ietf-quic-qlog-quic-events-03",
+      "draft-ietf-quic-qlog-quic-h3-events-03"
+    ],
     "title": "Name of this particular qlog file (short)",
     "description": "Description for this group of traces (long)",
     "traces": [...]
@@ -876,7 +889,7 @@ trace has a different value for a given field, this field MUST NOT be added to
 common_fields but instead defined on each event individually. Good example of such
 fields are "time" and "data", who are divergent by nature.
 
-# Guidelines for event definition documents
+# Guidelines for event definition documents {#guidelines}
 
 This document only defines the main schema for the qlog format. This is intended
 to be used together with specific, per-protocol event definitions that specify the

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -87,9 +87,9 @@ fields.
 # Overview
 
 This document describes how the QUIC protocol is can be expressed in qlog using
-the schema defined in {{QLOG-MAIN}}. QUIC protocol events are defined with a
-category, a name (the concatenation of "category" and "event"), an "importance",
-an optional "trigger", and "data" fields.
+the schema defined in {{QLOG-MAIN}} with "qlog_version" of "0.4". QUIC protocol
+events are defined with a category, a name (the concatenation of "category" and
+"event"), an "importance", an optional "trigger", and "data" fields.
 
 Some data fields use complex datastructures. These are represented as enums or
 re-usable definitions, which are grouped together on the bottom of this document


### PR DESCRIPTION
This adds the additional_schema field to QlogFile defined in the main
schema. The purpose being to explicitly identify the schema used for
additional events (possibly) included in qlog traces.

The field is free-forma and could be anything. We could go XML style
and require a URL. I've started by just proposing that we reference
the document name:

for I-Ds, this makes it easy to manage iterative versions
for RFCs, these have a canonical source already. If an RFC update
is published and an implementation switches to it, we can change
easily.

Closes #283
