### PR TITLE
Add missing QUIC transport error values

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1878,7 +1878,7 @@ TransportError = "no_error" / "internal_error" /
     "protocol_violation" / "invalid_token" / "application_error" /
     "crypto_buffer_exceeded" / "key_update_error" / "aead_limit_reached" /
     "no_viable_path"
-    ; there is no value to reflect CRYPTO_ERROR, instead use CryptoError type
+    ; there is no value to reflect CRYPTO_ERROR; use the CryptoError type instead
 ~~~
 {: #transporterror-def title="TransportError definition"}
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1876,7 +1876,9 @@ TransportError = "no_error" / "internal_error" /
     "final_size_error" / "frame_encoding_error" /
     "transport_parameter_error" / "connection_id_limit_error" /
     "protocol_violation" / "invalid_token" / "application_error" /
-    "crypto_buffer_exceeded"
+    "crypto_buffer_exceeded" / "key_update_error" / "aead_limit_reached" /
+    "no_viable_path"
+    ; there is no value to reflect CRYPTO_ERROR, instead use CryptoError type
 ~~~
 {: #transporterror-def title="TransportError definition"}
 


### PR DESCRIPTION
Adds missing code points except for CRYPTO_ERROR. Since we make an
explicit choice to represent that as a CryptoError type, call that
out in a note

Fixes #129
