### PR TITLE
Move HTTP/3 events and their related data to their own prefix

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -446,13 +446,13 @@ headers: [
 ~~~ cddl
 H3HeadersFrame = {
     frame_type: "headers"
-    headers: [* HTTPField]
+    headers: [* H3HTTPField]
 }
 ~~~
 {: #h3-headersframe-def title="H3HeadersFrame definition"}
 
 ~~~ cddl
-HTTPField = {
+H3HTTPField = {
     name: text
     value: text
 }


### PR DESCRIPTION
Since most of these events are HTTP/3 specific, lets just rename them to
use an H3 prefix.

The one exception is `HTTPField` because it is actually aligned to HTTP
Semantics rather than any particular wire format.

Fixes #286
