### PR TITLE
Add QUIC and HTTP/3 DATAGRAM frame definitions

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -60,8 +60,9 @@ level schema defined in {{QLOG-MAIN}}.
 # Introduction
 
 This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for HTTP/3 {{RFC9114}} and QPACK
-{{!QPACK=RFC9204}}.
+"data" fields and their semantics for the HTTP/3 protocol {{!HTTP3=RFC9114}},
+QPACK {{!QPACK=RFC9204}}, and some of their extensions (see
+{{!H3-DATAGRAM=RFC9297}}).
 
 > Note to RFC editor: Please remove the follow paragraphs in this section before
 publication.
@@ -195,9 +196,15 @@ H3ParametersSet = {
 }
 
 H3Parameters = {
+    ; RFC9114
     ? max_field_section_size: uint64
+
+    ; RFC9204
     ? max_table_capacity: uint64
     ? blocked_streams_count: uint64
+
+    ; RFC9297 (SETTINGS_H3_DATAGRAM)
+    ? h3_datagram: uint16
 
     ; additional settings for grease and extensions
     * text => uint64
@@ -206,7 +213,7 @@ H3Parameters = {
 {: #h3-parametersset-def title="H3ParametersSet definition"}
 
 This event can contain any number of unspecified fields. This allows for
-representation of reserved settings (aka grease) or ad-hoc support for
+representation of reserved settings (aka GREASE) or ad-hoc support for
 extension settings that do not have a related qlog schema definition.
 
 ## parameters_restored {#h3-parametersrestored}
@@ -365,7 +372,8 @@ H3BaseFrames = H3DataFrame /
                H3GoawayFrame /
                H3MaxPushIDFrame /
                H3ReservedFrame /
-               H3UnknownFrame
+               H3UnknownFrame /
+               H3DatagramFrame
 
 $H3Frame /= H3BaseFrames
 ~~~
@@ -507,6 +515,19 @@ H3UnknownFrame = {
 }
 ~~~
 {: #h3unknownframe-def title="UnknownFrame definition"}
+
+## H3DatagramFrame Definition
+
+The HTTP/3 DATAGRAM frame is defined in {{Section 2 of !RFC9297}}.
+
+~~~ cddl
+H3DatagramFrame = {
+    frame_type: "datagram"
+    quarter_stream_id: uint64
+    ? raw: RawInfo
+}
+~~~
+{: #h3datagramframe-def title="h3datagramframe definition"}
 
 ### H3ApplicationError
 

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -134,6 +134,8 @@ in this specification.
 | h3:stream_type_set        | Base       | {{h3-streamtypeset}} |
 | h3:frame_created          | Core       | {{h3-framecreated}} |
 | h3:frame_parsed           | Core       | {{h3-frameparsed}} |
+| h3:datagram_created       | Base       | {{h3-datagramcreated}} |
+| h3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
 | h3:push_resolved          | Extra      | {{h3-pushresolved}} |
 | qpack:state_updated         | Base       | {{qpack-stateupdated}} |
 | qpack:stream_state_updated  | Core       | {{qpack-streamstateupdate}} |
@@ -154,6 +156,8 @@ H3Events = H3ParametersSet /
            H3StreamTypeSet /
            H3FrameCreated /
            H3FrameParsed /
+           H3DatagramCreated /
+           H3DatagramParsed /
            H3PushResolved
 
 $ProtocolEventBody /= H3Events
@@ -161,10 +165,10 @@ $ProtocolEventBody /= H3Events
 {: #h3-events-def title="H3Events definition and ProtocolEventBody
 extension"}
 
-HTTP events are logged when a certain condition happens at the application layer,
-and there isn't always a one to one mapping between HTTP and QUIC events.
+HTTP events are logged when a certain condition happens at the application
+layer, and there isn't always a one to one mapping between HTTP and QUIC events.
 The exchange of data between the HTTP and QUIC layer is logged via the
-"data_moved" event in {{QLOG-QUIC}}.
+"stream_data_moved" and "datagram_data_moved" events in {{QLOG-QUIC}}.
 
 ## parameters_set {#h3-parametersset}
 Importance: Base
@@ -273,7 +277,7 @@ Importance: Core
 
 This event is emitted when the HTTP/3 framing actually happens. This does not
 necessarily coincide with HTTP/3 data getting passed to the QUIC layer. For
-that, see the "data_moved" event in {{QLOG-QUIC}}.
+that, see the "stream_data_moved" event in {{QLOG-QUIC}}.
 
 Definition:
 
@@ -292,7 +296,7 @@ Importance: Core
 
 This event is emitted when the HTTP/3 frame is parsed. This is not
 necessarily the same as when the HTTP/3 data is actually received on the QUIC
-layer. For that, see the "data_moved" event in {{QLOG-QUIC}}.
+layer. For that, see the "stream_data_moved" event in {{QLOG-QUIC}}.
 
 Definition:
 
@@ -309,7 +313,44 @@ H3FrameParsed = {
 HTTP/3 DATA frames can have arbitrarily large lengths to reduce frame header
 overhead. As such, DATA frames can span multiple QUIC packets. In this case, the
 frame_parsed event is emitted once for the frame header, and further streamed
-data is indicated using the data_moved event.
+data is indicated using the stream_data_moved event.
+
+## datagram_created {#h3-datagramcreated}
+Importance: Base
+
+This event is emitted when an HTTP/3 Datagram is created (see {{!RFC9297}}).
+This does not necessarily coincide with the HTTP/3 Datagram getting passed to
+the QUIC layer. For that, see the "datagram_data_moved" event in {{QLOG-QUIC}}.
+
+Definition:
+
+~~~ cddl
+H3DatagramCreated = {
+    quarter_stream_id: uint64
+    ? datagram: $H3Datagram
+    ? raw: RawInfo
+}
+~~~
+{: #h3-datagramcreated-def title="H3DatagramCreated definition"}
+
+## datagram_parsed {#h3-datagramparsed}
+Importance: Base
+
+This event is emitted when the HTTP/3 Datagram is parsed (see {{!RFC9297}}).
+This is not necessarily the same as when the HTTP/3 Datagram is actually
+received on the QUIC layer. For that, see the "datagram_data_moved" event in
+{{QLOG-QUIC}}.
+
+Definition:
+
+~~~ cddl
+H3DatagramParsed = {
+    quarter_stream_id: uint64
+    ? datagram: $H3Datagram
+    ? raw: RawInfo
+}
+~~~
+{: #h3-datagramparsed-def title="H3DatagramParsed definition"}
 
 ## push_resolved {#h3-pushresolved}
 Importance: Extra
@@ -372,12 +413,25 @@ H3BaseFrames = H3DataFrame /
                H3GoawayFrame /
                H3MaxPushIDFrame /
                H3ReservedFrame /
-               H3UnknownFrame /
-               H3DatagramFrame
+               H3UnknownFrame
 
 $H3Frame /= H3BaseFrames
 ~~~
 {: #h3baseframe-def title="H3BaseFrames definition"}
+
+## H3Datagram
+
+The generic `$H3Datagram` is defined here as a CDDL extension point (a "socket"
+or "plug"). It can be extended to support additional HTTP/3 datagram types. This
+document intentionally does not define any specific HTTP/3 Datagram types.
+
+~~~ cddl
+; The H3Datagram is any key-value map (e.g., JSON object)
+$H3Datagram /= {
+    * text => any
+}
+~~~
+{: #h3-datagram-def title="H3Datagram plug definition"}
 
 ### H3DataFrame
 
@@ -515,19 +569,6 @@ H3UnknownFrame = {
 }
 ~~~
 {: #h3unknownframe-def title="UnknownFrame definition"}
-
-## H3DatagramFrame Definition
-
-The HTTP/3 DATAGRAM frame is defined in {{Section 2 of !RFC9297}}.
-
-~~~ cddl
-H3DatagramFrame = {
-    frame_type: "datagram"
-    quarter_stream_id: uint64
-    ? raw: RawInfo
-}
-~~~
-{: #h3datagramframe-def title="h3datagramframe definition"}
 
 ### H3ApplicationError
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -187,7 +187,8 @@ this specification.
 | quic:datagram_dropped            | Extra      | {{quic-datagramdropped}} |
 | quic:stream_state_updated        | Base       | {{quic-streamstateupdated}} |
 | quic:frames_processed            | Extra      | {{quic-framesprocessed}} |
-| quic:data_moved                  | Base       | {{quic-datamoved}} |
+| quic:stream_data_moved                | Base       | {{quic-streamdatamoved}} |
+| quic:datagram_data_moved              | Base       | {{quic-datagramdatamoved}} |
 | security:key_updated                  | Base       | {{security-keyupdated}} |
 | security:key_discarded                | Base       | {{security-keydiscarded}} |
 | recovery:parameters_set               | Base       | {{recovery-parametersset}} |
@@ -225,7 +226,8 @@ QuicEvents = ConnectivityServerListening /
              QUICDatagramDropped /
              QUICStreamStateUpdated /
              QUICFramesProcessed /
-             QUICDataMoved /
+             QUICStreamDataMoved /
+             QUICDatagramDataMoved /
              RecoveryParametersSet /
              RecoveryMetricsUpdated /
              RecoveryCongestionStateUpdated /
@@ -1031,26 +1033,30 @@ QUICFramesProcessed = {
 ~~~
 {: #quic-framesprocessed-def title="QUICFramesProcessed definition"}
 
-## data_moved {#quic-datamoved}
+## stream_data_moved {#quic-streamdatamoved}
 Importance: Base
 
-Used to indicate when data moves between the different layers (for example passing
-from the application protocol (e.g., HTTP) to QUIC stream buffers and vice versa)
-or between the application protocol (e.g., HTTP) and the actual user application
-on top (for example a browser engine). This helps make clear the flow of data, how
-long data remains in various buffers and the overheads introduced by individual
-layers.
+Used to indicate when QUIC stream data moves between the different layers (for
+example passing from the application protocol (e.g., HTTP) to QUIC stream
+buffers and vice versa) or between the application protocol (e.g., HTTP) and the
+actual user application on top (for example a browser engine). This helps make
+clear the flow of data, how long data remains in various buffers and the
+overheads introduced by individual layers.
 
-For example, this helps make clear whether received data on a QUIC stream is moved
-to the application protocol immediately (for example per received packet) or in
-larger batches (for example, all QUIC packets are processed first and afterwards
-the application layer reads from the streams with newly available data). This in
-turn can help identify bottlenecks or scheduling problems.
+For example, this helps make clear whether received data on a QUIC stream is
+moved to the application protocol immediately (for example per received packet)
+or in larger batches (for example, all QUIC packets are processed first and
+afterwards the application layer reads from the streams with newly available
+data). This in turn can help identify bottlenecks, flow control issues or
+scheduling problems.
+
+This event is only for data in QUIC streams. For data in QUIC Datagram Frames,
+see {{quic-datagramdatamoved}}.
 
 Definition:
 
 ~~~ cddl
-QUICDataMoved = {
+QUICStreamDataMoved = {
     ? stream_id: uint64
     ? offset: uint64
 
@@ -1069,7 +1075,49 @@ QUICDataMoved = {
     ? raw: RawInfo
 }
 ~~~
-{: #quic-datamoved-def title="QUICDataMoved definition"}
+{: #quic-streamdatamoved-def title="QUICStreamDataMoved definition"}
+
+
+## datagram_data_moved {#quic-datagramdatamoved}
+Importance: Base
+
+Used to indicate when QUIC Datagram Frame data (see {{!RFC9221}}) moves between
+the different layers (for example passing from the application protocol (e.g.,
+WebTransport) to QUIC Datagram Frame buffers and vice versa) or between the
+application protocol and the actual user application on top (for example a
+gaming engine or media playback software). This helps make clear the flow of
+data, how long data remains in various buffers and the overheads introduced by
+individual layers.
+
+For example, this helps make clear whether received data in a QUIC Datagram
+Frame is moved to the application protocol immediately (for example per received
+packet) or in larger batches (for example, all QUIC packets are processed first
+and afterwards the application layer reads all Datagrams at once). This in turn
+can help identify bottlenecks or scheduling problems.
+
+This event is only for data in QUIC Datagram Frames. For data in QUIC streams,
+see {{quic-streamdatamoved}}.
+
+Definition:
+
+~~~ cddl
+QUICDatagramDataMoved = {
+    ; byte length of the moved data
+    ? length: uint64
+    ? from: "user" /
+            "application" /
+            "transport" /
+            "network" /
+            text
+    ? to: "user" /
+          "application" /
+          "transport" /
+          "network" /
+          text
+    ? raw: RawInfo
+}
+~~~
+{: #quic-datagramdatamoved-def title="QUICDatagramDataMoved definition"}
 
 # Security Events {#sec-ev}
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -54,8 +54,9 @@ in {{QLOG-MAIN}}.
 # Introduction
 
 This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for QUIC; see {{!QUIC-TRANSPORT=RFC9000}},
-{{!QUIC-RECOVERY=RFC9002}}, and {{!QUIC-TLS=RFC9003}}.
+"data" fields and their semantics for the QUIC protocol (see
+{{!QUIC-TRANSPORT=RFC9000}}, {{!QUIC-RECOVERY=RFC9002}}, and
+{{!QUIC-TLS=RFC9003}}) and some of its extensions (see {{!QUIC-DATAGRAM=RFC9221}}).
 
 > Note to RFC editor: Please remove the follow paragraphs in this section before
 publication.
@@ -605,7 +606,7 @@ QUICParametersSet = {
     ; e.g., "AES_128_GCM_SHA256"
     ? tls_cipher: text
 
-    ; transport parameters from the TLS layer:
+    ; RFC9000
     ? original_destination_connection_id: ConnectionID
     ? initial_source_connection_id: ConnectionID
     ? retry_source_connection_id: ConnectionID
@@ -623,6 +624,9 @@ QUICParametersSet = {
     ? initial_max_streams_bidi: uint64
     ? initial_max_streams_uni: uint64
     ? preferred_address: PreferredAddress
+
+    ; RFC9221
+    ? max_datagram_frame_size: uint64
 }
 
 PreferredAddress = {
@@ -1529,7 +1533,8 @@ QuicBaseFrames /= PaddingFrame /
                   PathResponseFrame /
                   ConnectionCloseFrame /
                   HandshakeDoneFrame /
-                  UnknownFrame
+                  UnknownFrame /
+                  DatagramFrame
 
 $QuicFrame /= QuicBaseFrames
 ~~~
@@ -1848,6 +1853,19 @@ UnknownFrame = {
 }
 ~~~
 {: #unknownframe-def title="UnknownFrame definition"}
+
+### DatagramFrame
+
+The QUIC DATAGRAM frame is defined in {{Section 4 of !RFC9221}}.
+
+~~~ cddl
+DatagramFrame = {
+    frame_type: "datagram"
+    ? length: uint64
+    ? raw: RawInfo
+}
+~~~
+{: #datagramframe-def title="DatagramFrame definition"}
 
 ### TransportError
 


### PR DESCRIPTION
As discussed at IETF 115 and 116, we will add support for most RFC-status QUIC and HTTP/3 extensions to the main documents.

This PR adds our intended support for RFCs 9221 and 9297. Note that this does NOT include full support for those entire documents. Specifically, we only add the QUIC and H3 DATAGRAM frames, not the full "capsule protocol", which was deemed out of scope for the core qlog documents. 

These changes were originally part of a separate document at https://github.com/rmarx/draft-marx-quic-qlog-datagram, which is now deprecated. 