### PR TITLE
Add definitions for RFC9287 (QUIC GREASE Bit extension)

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -57,6 +57,9 @@ This document describes the values of the qlog name ("category" + "event") and
 "data" fields and their semantics for QUIC; see {{!QUIC-TRANSPORT=RFC9000}},
 {{!QUIC-RECOVERY=RFC9002}}, and {{!QUIC-TLS=RFC9003}}.
 
+This document also adds events and fields for {{!GREASEBIT=RFC9287}} (TODO:
+update this once #310 is merged).
+
 > Note to RFC editor: Please remove the follow paragraphs in this section before
 publication.
 
@@ -623,6 +626,10 @@ QUICParametersSet = {
     ? initial_max_streams_bidi: uint64
     ? initial_max_streams_uni: uint64
     ? preferred_address: PreferredAddress
+
+    ; RFC9287
+    ; true if present, absent or false if extension not negotiated
+    ? grease_quic_bit: bool
 }
 
 PreferredAddress = {
@@ -1441,6 +1448,9 @@ PacketHeader = {
     ? dcil: uint8
     ? scid: ConnectionID
     ? dcid: ConnectionID
+
+    ; RFC9287
+    ? quic_bit: bool .default true
 }
 ~~~
 {: #packetheader-def title="PacketHeader definition"}

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1422,6 +1422,7 @@ PacketNumberSpace = "initial" /
 
 ~~~ cddl
 PacketHeader = {
+    ? quic_bit: bool .default true
     packet_type: PacketType
 
     ; only if packet_type === "initial" || "handshake" || "0RTT" ||
@@ -1448,9 +1449,6 @@ PacketHeader = {
     ? dcil: uint8
     ? scid: ConnectionID
     ? dcid: ConnectionID
-
-    ; RFC9287
-    ? quic_bit: bool .default true
 }
 ~~~
 {: #packetheader-def title="PacketHeader definition"}


### PR DESCRIPTION
Adds support for [RFC 9287](https://www.rfc-editor.org/rfc/rfc9287.html).

There were two possible approaches to the design:
1. what I have done now (add it as a field in the `PacketHeader`)
2. add it in a separate event like `spin_bit_updated`

While 2. might seem the more consistent option, I think 1. actually makes more sense here. For the Spin bit, you will usually have a long streak of packets/events with the spin bit set to a certain value, so an event only when it updates makes sense.

For the GREASE bit, you can/should have unpredictable values on a per-packet basis, so this could lead to very verbose update events.