### PR TITLE
Move changelog to end

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -1063,9 +1063,21 @@ TBD
 
 --- back
 
+# Acknowledgements
+{:numbered="false"}
+
+Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
+Universities.
+
+Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
+Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
+Yamamoto, and Christian Huitema for their feedback and suggestions.
+
 # Change Log
+{:numbered="false" removeinrfc="true"}
 
 ## Since draft-ietf-quic-qlog-h3-events-04:
+{:numbered="false"}
 
 * Renamed 'http' category to 'h3' (#300)
 * H3HTTPField.value is now optional (#296)
@@ -1075,6 +1087,7 @@ TBD
 * Editorial and formatting changes (#298, #258, #299, #304, #327)
 
 ## Since draft-ietf-quic-qlog-h3-events-03:
+{:numbered="false"}
 
 * Ensured consistent use of RawInfo to indicate raw wire bytes (#243)
 * Changed HTTPStreamTypeSet:raw_stream_type to stream_type_value (#54)
@@ -1082,6 +1095,7 @@ TBD
 * Renamed max_header_list_size to max_field_section_size (#282)
 
 ## Since draft-ietf-quic-qlog-h3-events-02:
+{:numbered="false"}
 
 * Renamed HTTPStreamType data to request (#222)
 * Added HTTPStreamType value unknown (#227)
@@ -1092,14 +1106,17 @@ TBD
 * Added overview Table of Contents
 
 ## Since draft-ietf-quic-qlog-h3-events-01:
+{:numbered="false"}
 
 * No changes - new draft to prevent expiration
 
 ## Since draft-ietf-quic-qlog-h3-events-00:
+{:numbered="false"}
 
 * Change the data definition language from TypeScript to CDDL (#143)
 
 ## Since draft-marx-qlog-event-definitions-quic-h3-02:
+{:numbered="false"}
 
 * These changes were done in preparation of the adoption of the drafts by the QUIC
   working group (#137)
@@ -1108,6 +1125,7 @@ TBD
   schema document.
 
 ## Since draft-marx-qlog-event-definitions-quic-h3-01:
+{:numbered="false"}
 
 Major changes:
 
@@ -1149,8 +1167,8 @@ Smaller changes:
   coalesced QUIC packets (#91)
 * Extended connection_state_updated with more fine-grained states (#49)
 
-
 ## Since draft-marx-qlog-event-definitions-quic-h3-00:
+{:numbered="false"}
 
 * Event and category names are now all lowercase
 * Added many new events and their definitions
@@ -1159,14 +1177,3 @@ Smaller changes:
 * Events are given an importance indicator (issue \#22)
 * Event names are more consistent and use past tense (issue \#21)
 * Triggers have been redefined as properties of the "data" field and updated for most events (issue \#23)
-
-# Acknowledgements
-{:numbered="false"}
-
-Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
-Universities.
-
-Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
-Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, and Christian Huitema for their feedback and suggestions.
-

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1821,9 +1821,21 @@ There are no IANA considerations.
 
 --- back
 
+# Acknowledgements
+{:numbered="false"}
+
+Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
+Universities.
+
+Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
+Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, and Jeremy Lainé for
+their feedback and suggestions.
+
 # Change Log
+{:numbered="false" removeinrfc="true"}
 
 ## Since draft-ietf-quic-qlog-main-schema-05:
+{:numbered="false"}
 
 * Updated qlog_version to 0.4 (due to breaking changes) (#314)
 * Renamed 'transport' category to 'quic' (#302)
@@ -1832,22 +1844,27 @@ There are no IANA considerations.
 * Editorial and formatting changes (#298, #303, #304, #316, #320, #321, #322, #326, #328)
 
 ## Since draft-ietf-quic-qlog-main-schema-04:
+{:numbered="false"}
 
 * Updated RawInfo definition and guidance (#243)
 
 ## Since draft-ietf-quic-qlog-main-schema-03:
+{:numbered="false"}
 
 * Added security and privacy considerations discussion (#252)
 
 ## Since draft-ietf-quic-qlog-main-schema-02:
+{:numbered="false"}
 
 * No changes - new draft to prevent expiration
 
 ## Since draft-ietf-quic-qlog-main-schema-01:
+{:numbered="false"}
 
 * Change the data definition language from TypeScript to CDDL (#143)
 
 ## Since draft-ietf-quic-qlog-main-schema-00:
+{:numbered="false"}
 
 * Changed the streaming serialization format from NDJSON to JSON Text Sequences
   (#172)
@@ -1855,6 +1872,7 @@ There are no IANA considerations.
 * Changed to semantic versioning
 
 ## Since draft-marx-qlog-main-schema-draft-02:
+{:numbered="false"}
 
 * These changes were done in preparation of the adoption of the drafts by the QUIC
   working group (#137)
@@ -1863,6 +1881,7 @@ There are no IANA considerations.
 * Made protocol_type an array instead of a string (#146)
 
 ## Since draft-marx-qlog-main-schema-01:
+{:numbered="false"}
 
 * Decoupled qlog from the JSON format and described a mapping instead (#89)
     * Data types are now specified in this document and proper definitions for
@@ -1880,21 +1899,10 @@ There are no IANA considerations.
   usage (#26,#33,#51)
 * Overall tightened up the text and added more examples
 
-
 ## Since draft-marx-qlog-main-schema-00:
+{:numbered="false"}
 
 * All field names are now lowercase (e.g., category instead of CATEGORY)
 * Triggers are now properties on the "data" field value, instead of separate field
   types (#23)
 * group_ids in common_fields is now just also group_id
-
-# Acknowledgements
-{:numbered="false"}
-
-Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
-Universities.
-
-Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
-Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, and Jeremy Lainé for
-their feedback and suggestions.
-

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1999,10 +1999,21 @@ TBD
 
 --- back
 
+# Acknowledgements
+{:numbered="false"}
+
+Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
+Universities.
+
+Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
+Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
+Yamamoto, and Christian Huitema for their feedback and suggestions.
 
 # Change Log
+{:numbered="false" removeinrfc="true"}
 
 ## Since draft-ietf-qlog-quic-events-04:
+{:numbered="false"}
 
 * Updated guidance on logging events across connections (#279)
 * Renamed 'transport' category to 'quic' (#302)
@@ -2013,6 +2024,7 @@ TBD
 * Editorial and formatting changes (#298, #299, #304, #306, #327)
 
 ## Since draft-ietf-qlog-quic-events-03:
+{:numbered="false"}
 
 * Ensured consistent use of RawInfo to indicate raw wire bytes (#243)
 * Renamed UnknownFrame:raw_frame_type to :frame_type_value (#54)
@@ -2022,6 +2034,7 @@ TBD
 * Changed minimum_congestion_window to uint64 (#288)
 
 ## Since draft-ietf-qlog-quic-events-02:
+{:numbered="false"}
 
 * Renamed key_retired to key_discarded (#185)
 * Added fields and events for DPLPMTUD (#135)
@@ -2032,14 +2045,17 @@ TBD
 * Added overview Table of Contents
 
 ## Since draft-ietf-qlog-quic-events-01:
+{:numbered="false"}
 
 * Added Stateless Reset Token type (#122)
 
 ## Since draft-ietf-qlog-quic-events-00:
+{:numbered="false"}
 
 * Change the data definition language from TypeScript to CDDL (#143)
 
 ## Since draft-marx-qlog-event-definitions-quic-h3-02:
+{:numbered="false"}
 
 * These changes were done in preparation of the adoption of the drafts by the QUIC
   working group (#137)
@@ -2049,6 +2065,7 @@ TBD
 * Changed to/from value options of the `data_moved` event
 
 ## Since draft-marx-qlog-event-definitions-quic-h3-01:
+{:numbered="false"}
 
 Major changes:
 
@@ -2090,8 +2107,8 @@ Smaller changes:
   coalesced QUIC packets (#91)
 * Extended connection_state_updated with more fine-grained states (#49)
 
-
 ## Since draft-marx-qlog-event-definitions-quic-h3-00:
+{:numbered="false"}
 
 * Event and category names are now all lowercase
 * Added many new events and their definitions
@@ -2100,13 +2117,3 @@ Smaller changes:
 * Events are given an importance indicator (issue \#22)
 * Event names are more consistent and use past tense (issue \#21)
 * Triggers have been redefined as properties of the "data" field and updated for most events (issue \#23)
-
-# Acknowledgements
-{:numbered="false"}
-
-Much of the initial work by Robin Marx was done at the Hasselt and KU Leuven
-Universities.
-
-Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
-Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, and Christian Huitema for their feedback and suggestions.


### PR DESCRIPTION
This section will be removed, so putting it as the first appendix
means that there's a potential for more churn later on.

This change updates the changelog section metadata and moves it to the end.
