### PR TITLE
add a packet_dropped trigger for duplicate packets

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -786,6 +786,7 @@ QUICPacketDropped = {
         "rejected" /
         "unsupported" /
         "invalid" /
+        "duplicate" /
         "connection_unknown" /
         "decryption_failure" /
         "general"
@@ -799,6 +800,7 @@ Some example situations for each of the trigger categories include:
 - rejected: limits reached, DDoS protection, unwilling to track more paths, duplicate packet
 - unsupported: unknown or unsupported version. See also {{handling-unknown-connections}}.
 - invalid: packet parsing or validation error
+- duplicate: duplicate packet
 - connection_unknown: packet does not relate to a known connection or Connection ID
 - decryption_failure: decryption key was unavailable, decryption failed
 - general: situations not clearly covered in the other categories


### PR DESCRIPTION
See section 12.3 of RFC 9000:

> A receiver MUST discard a newly unprotected packet unless it is certain that it has not processed another packet with the same packet number from the same packet number space. Duplicate suppression MUST happen after removing packet protection for the reasons described in Section 9.5 of [QUIC-TLS].