### PR TITLE
Align terminology across $ProtocolEvent extension point

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -143,22 +143,22 @@ in this specification.
 
 # HTTP/3 Events {#h3-ev}
 
-HTTP/3 events extend the `$ProtocolEventBody` extension point defined in {{QLOG-MAIN}}.
+HTTP/3 events extend the `$ProtocolEventData` extension point defined in {{QLOG-MAIN}}.
 
 ~~~ cddl
-H3Events = H3ParametersSet /
-           H3ParametersRestored /
-           H3StreamTypeSet /
-           H3PriorityUpdated /
-           H3FrameCreated /
-           H3FrameParsed /
-           H3DatagramCreated /
-           H3DatagramParsed /
-           H3PushResolved
+H3EventData = H3ParametersSet /
+              H3ParametersRestored /
+              H3StreamTypeSet /
+              H3PriorityUpdated /
+              H3FrameCreated /
+              H3FrameParsed /
+              H3DatagramCreated /
+              H3DatagramParsed /
+              H3PushResolved
 
-$ProtocolEventBody /= H3Events
+$ProtocolEventData /= H3EventData
 ~~~
-{: #h3-events-def title="H3Events definition and ProtocolEventBody
+{: #h3-events-def title="H3EventData definition and ProtocolEventData
 extension"}
 
 HTTP events are logged when a certain condition happens at the application

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -495,7 +495,7 @@ An Event is defined in {{event-def}} as:
 Event = {
     time: float64
     name: text
-    data: $ProtocolEventBody
+    data: $ProtocolEventData
     ? time_format: TimeFormat
     ? protocol_type: ProtocolType
     ? group_id: GroupID
@@ -647,7 +647,7 @@ field value definitions for QUIC and HTTP/3 can be found in {{QLOG-QUIC}} and
 {{QLOG-H3}}.
 
 This field is defined here as a CDDL extension point (a "socket" or
-"plug") named `$ProtocolEventBody`. Other documents MUST properly extend
+"plug") named `$ProtocolEventData`. Other documents MUST properly extend
 this extension point when defining new data field content options to
 enable automated validation of aggregated qlog schemas.
 
@@ -657,20 +657,20 @@ which is discussed in {{trigger-field}}.
 Definition:
 
 ~~~ cddl
-; The ProtocolEventBody is any key-value map (e.g., JSON object)
+; The ProtocolEventData is any key-value map (e.g., JSON object)
 ; only the optional trigger field is defined in this document
-$ProtocolEventBody /= {
+$ProtocolEventData /= {
     ? trigger: text
     * text => any
 }
 ; event documents are intended to extend this socket by using:
-; NewProtocolEvents = EventType1 /
-;                     EventType2 /
-;                     ... /
-;                     EventTypeN
-; $ProtocolEventBody /= NewProtocolEvents
+; NewProtocolEventData = EventType1 /
+;                        EventType2 /
+;                        ... /
+;                        EventTypeN
+; $ProtocolEventData /= NewProtocolEventData
 ~~~
-{: #protocoleventbody-def title="ProtocolEventBody definition"}
+{: #protocoleventdata-def title="ProtocolEventData definition"}
 
 One purely illustrative example for a QUIC "packet_sent" event is shown in
 {{data-ex}}:

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -202,44 +202,44 @@ this specification.
 | recovery:ecn_state_updated            | Extra      | {{recovery-ecnstateupdated}} |
 {: #quic-events title="QUIC Events"}
 
-QUIC events extend the `$ProtocolEventBody` extension point defined in
+QUIC events extend the `$ProtocolEventData` extension point defined in
 {{QLOG-MAIN}}.
 
 ~~~ cddl
-QuicEvents = ConnectivityServerListening /
-             ConnectivityConnectionStarted /
-             ConnectivityConnectionClosed /
-             ConnectivityConnectionIDUpdated /
-             ConnectivitySpinBitUpdated /
-             ConnectivityConnectionStateUpdated /
-             ConnectivityMTUUpdated /
-             SecurityKeyUpdated /
-             SecurityKeyDiscarded /
-             QUICVersionInformation /
-             QUICALPNInformation /
-             QUICParametersSet /
-             QUICParametersRestored /
-             QUICPacketSent /
-             QUICPacketReceived /
-             QUICPacketDropped /
-             QUICPacketBuffered /
-             QUICPacketsAcked /
-             QUICDatagramsSent /
-             QUICDatagramsReceived /
-             QUICDatagramDropped /
-             QUICStreamStateUpdated /
-             QUICFramesProcessed /
-             QUICStreamDataMoved /
-             QUICDatagramDataMoved /
-             RecoveryParametersSet /
-             RecoveryMetricsUpdated /
-             RecoveryCongestionStateUpdated /
-             RecoveryLossTimerUpdated /
-             RecoveryPacketLost
+QuicEventData = ConnectivityServerListening /
+                ConnectivityConnectionStarted /
+                ConnectivityConnectionClosed /
+                ConnectivityConnectionIDUpdated /
+                ConnectivitySpinBitUpdated /
+                ConnectivityConnectionStateUpdated /
+                ConnectivityMTUUpdated /
+                SecurityKeyUpdated /
+                SecurityKeyDiscarded /
+                QUICVersionInformation /
+                QUICALPNInformation /
+                QUICParametersSet /
+                QUICParametersRestored /
+                QUICPacketSent /
+                QUICPacketReceived /
+                QUICPacketDropped /
+                QUICPacketBuffered /
+                QUICPacketsAcked /
+                QUICDatagramsSent /
+                QUICDatagramsReceived /
+                QUICDatagramDropped /
+                QUICStreamStateUpdated /
+                QUICFramesProcessed /
+                QUICStreamDataMoved /
+                QUICDatagramDataMoved /
+                RecoveryParametersSet /
+                RecoveryMetricsUpdated /
+                RecoveryCongestionStateUpdated /
+                RecoveryLossTimerUpdated /
+                RecoveryPacketLost
 
-$ProtocolEventBody /= QuicEvents
+$ProtocolEventData /= QuicEventData
 ~~~
-{: #quicevents-def title="QuicEvents definition and ProtocolEventBody
+{: #quicevent-data-def title="QuicEventData definition and ProtocolEventData
 extension"}
 
 # Connectivity events {#conn-ev}


### PR DESCRIPTION
As discussed on #131, there's a slight mismatch of terminology
between the main $ProtocolEventBody and the extensions QUICEvents
and H3Events.

This change implements the proposal to align the terms.

Close #131
