### PR TITLE
fix(quic-events): typo version_negotiation on *un*-supported version

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -494,10 +494,10 @@ The `version_information` event supports QUIC version negotiation; see {{Section
 6 of QUIC-TRANSPORT}}. It has Core importance level; see {{Section 9.2 of
 QLOG-MAIN}}.
 
-QUIC endpoints each have their own list of of QUIC versions they support. The
+QUIC endpoints each have their own list of QUIC versions they support. The
 client uses the most likely version in their first initial. If the server does
-support that version, it replies with a version_negotiation packet, containing
-supported versions. From this, the client selects a version. The
+not support that version, it replies with a version_negotiation packet,
+containing supported versions. From this, the client selects a version. The
 `version_information` event aggregates all this information in a single event
 type. It also allows logging of supported versions at an endpoint without actual
 version negotiation needing to happen.


### PR DESCRIPTION
The server sends a version_negotiation packet when it does *not* support the client version.

Also remove duplicate "of".