### PR TITLE
Add fin and reset_stream fields

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1157,12 +1157,12 @@ processed first and afterwards the application layer reads from the streams with
 newly available data). This can help identify bottlenecks, flow control issues,
 or scheduling problems.
 
-The `fin` and `reset_stream` fields support optional logging of information
+The `additional_info` field supports optional logging of information
 related to the stream state. For example, an application layer that moves data
-into transport and simultaneously ends the stream, can set `fin` to true. As
+into transport and simultaneously ends the stream, can log `fin_set`. As
 another example, a transport layer that has received an instruction to reset a
-stream can indicate this to the application layer using the `reset_stream`
-field. In both cases, the length-carrying fields (`length` or `raw`) can be
+stream can indicate this to the application layer using `reset_stream`.
+In both cases, the length-carrying fields (`length` or `raw`) can be
 omitted or contain zero values.
 
 This event is only for data in QUIC streams. For data in QUIC Datagram Frames,
@@ -1179,13 +1179,8 @@ QUICStreamDataMoved = {
     ? from: $DataLocation
     ? to: $DataLocation
 
+    ? additional_info: $DataMovedAdditionalInfo
 
-    ; this MAY be set any time,
-    ; but MUST only be set if the value is true
-    ; if absent, the value MUST be assumed to be false
-    ? fin: bool
-    ? reset_stream: $ApplicationError /
-                    uint64
     ? raw: RawInfo
 
     * $$quic-streamdatamoved-extension
@@ -1195,6 +1190,9 @@ $DataLocation /=  "user" /
                   "application" /
                   "transport" /
                   "network"
+
+$DataMovedAdditionalInfo /= "fin_set" /
+                            "stream_reset"
 ~~~
 {: #quic-streamdatamoved-def title="QUICStreamDataMoved definition"}
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1157,6 +1157,14 @@ processed first and afterwards the application layer reads from the streams with
 newly available data). This can help identify bottlenecks, flow control issues,
 or scheduling problems.
 
+The `fin` and `reset_stream` fields support optional logging of information
+related to the stream state. For example, an application layer that moves data
+into transport and simultaneously ends the stream, can set `fin` to true. As
+another example, a transport layer that has received an instruction to reset a
+stream can indicate this to the application layer using the `reset_stream`
+field. In both cases, the length-carrying fields (`length` or `raw`) can be
+omitted or contain zero values.
+
 This event is only for data in QUIC streams. For data in QUIC Datagram Frames,
 see the `datagram_data_moved` event defined in {{quic-datagramdatamoved}}.
 
@@ -1167,8 +1175,17 @@ QUICStreamDataMoved = {
 
     ; byte length of the moved data
     ? length: uint64
+
     ? from: $DataLocation
     ? to: $DataLocation
+
+
+    ; this MAY be set any time,
+    ; but MUST only be set if the value is true
+    ; if absent, the value MUST be assumed to be false
+    ? fin: bool
+    ? reset_stream: $ApplicationError /
+                    uint64
     ? raw: RawInfo
 
     * $$quic-streamdatamoved-extension


### PR DESCRIPTION
Fixes #375.

Per the discussion, it can be useful to know when an application triggers a
stream close, or when it receives one, without having to do offset/length maths.

I omitted stop_sending in this commit because it seems a little bit of a stretch,
mainly because it's wire image has no offset or final size. Also, STOP_SENDING
relates to asking the peer to do something, which further complicates the
(potential) use of offset and length fields.

An alternative would be to keep `fin` here but define new events for reset and
stop. Those could both contain from, to and error fields but only the reset
would have offset and length.
