### PR TITLE
Make Parameters events extensible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 cddl:
 	@for f in $(drafts_source); do \
 	    echo "Validating $$f"; \
-	    ./cddl_validate.sh $$f > /tmp/foo 2>&1 ; \
+	    ./cddl_validate.sh $$f > /tmp/foo-$$f 2>&1 ; \
 	    if [ $$? -eq 0 ]; then \
 	        echo "  OK"; \
 	    else \

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -29,7 +29,14 @@ function generate_aux_object() {
     echo "AuxObjectWithAllTypesForValidationOnly = {" >> $tmpfile
     for type in ${unused_types}; do
       lowercase_type=$(echo ${type} | tr '[:upper:]' '[:lower:]')
-      echo "    ${lowercase_type}_: ${type}" >> $tmpfile
+      # When using CDDL group sockets, they start with $$ 
+      # (see https://datatracker.ietf.org/doc/html/rfc8610#section-3.9)
+      # These should not be included in the list of all objects here,
+      # since this gives validation errors (e.g., $$my-socket-name is not a type)
+      # Group sockets aren't types, and shouldn't be listed as such here
+      if [[ $lowercase_type != \$\$* ]]; then
+        echo "    ${lowercase_type}_: ${type}" >> $tmpfile
+      fi
     done
     echo -e "}\n" >> $tmpfile
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -574,9 +574,9 @@ minimize the amount of events and to decouple conceptual setting impacts from
 their underlying mechanism for easier high-level reasoning. The event has Core
 importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
-All these settings are typically set once and never change. However, they are
-typically set at different times during the connection, so there will typically be
-several instances of this event with different fields set.
+Most of these settings are typically set once and never change. However, they
+are usually set at different times during the connection, so there will
+regularly be several instances of this event with different fields set.
 
 Note that some settings have two variations (one set locally, one requested by the
 remote peer). This is reflected in the `owner` field. As such, this field MUST be
@@ -627,6 +627,8 @@ QUICParametersSet = {
     ; RFC9287
     ; true if present, absent or false if extension not negotiated
     ? grease_quic_bit: bool
+
+    * $$quic-parametersset-extension
 }
 
 PreferredAddress = {
@@ -640,9 +642,17 @@ PreferredAddress = {
 ~~~
 {: #quic-parametersset-def title="QUICParametersSet definition"}
 
-Additionally, this event can contain any number of unspecified fields. This is
-to reflect setting of, for example, unknown (greased) transport parameters or
-custom extensions.
+The generic `$$quic-parametersset-extension` is defined here as a CDDL extension
+point (a "group socket"). It can be used to support additional, unknown, custom,
+and greased parameters. An example of such an extension can be found in
+{{parametersset-extension-example}}.
+
+~~~~~~~~
+$$quic-parametersset-extension //= (
+  ? new_transport_parameter: uint64
+)
+~~~~~~~~
+{: #parametersset-extension-example title="quic-parametersset-extension example"}
 
 ## parameters_restored {#quic-parametersrestored}
 
@@ -668,12 +678,15 @@ QUICParametersRestored = {
     ? initial_max_stream_data_uni: uint64
     ? initial_max_streams_bidi: uint64
     ? initial_max_streams_uni: uint64
+
+    * $$quic-parametersrestored-extension
 }
 ~~~
 {: #quic-parametersrestored-def title="QUICParametersRestored definition"}
 
-Note that, like the `parameters_set` event, this event can contain any number of
-unspecified fields to allow for additional/custom parameters.
+The generic `$$quic-parametersrestored-extension` is defined here as a CDDL
+extension point (a "group socket"). It can be used to support additional and
+custom parameters.
 
 ## packet_sent {#quic-packetsent}
 


### PR DESCRIPTION
Fixes #176.

This uses CDDL's "group socket" (https://datatracker.ietf.org/doc/html/rfc8610#section-3.9) to allow others to later specify additional parameters that can be logged to the event in a typed/explicit way. 

Example in a later document (say for reliable stream resets):

```
$$quic-parametersset-extension //= (
  reliable_stream_reset: text
)
```

One conceptual "downside" is that by definition all fields in the extension will be optional, even if not preceded by a `?` (as in the example above). This is because the extension isn't yet known when processing the current definition, so it has to be either `?` (optional) or `*` (0 or more, which is used here as it's recommended by RFC8610). I don't see this as a major issue, but something to be aware of. 

