### PR TITLE
Add clarification on is_coalesced and add it to more events

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -886,12 +886,14 @@ excludes UDP-level headers in all RawInfo fields.
 Multiple QUIC packets can be coalesced in a single UDP datagram, especially
 during the handshake (see {{Section 12.2 of QUIC-TRANSPORT}}). However, neither
 QUIC nor UDP themselves provide an explicit mechanism to track this behaviour.
-Implementations willing to track coalescing across packet-level and
-datagram-level qlog events SHOULD thus use the local and qlog-specific concept
-of a "datagram identifier" in the `datagram_id` field. Selecting specific and
-locally unique `datagram_id` values is left to qlog implementations, but in
-general multiple packet-level events sharing the same `datagram_id` SHOULD
-indicate they were coalesced in the same UDP datagram.
+To make it possible for implementations to track coalescing across packet-level
+and datagram-level qlog events, this document defines a qlog-specific mechanism
+for tracking coalescing across packet-level and datagram-level qlog events: a
+"datagram identifier" carried in `datagram_id` fields. qlog implementations that
+want to track coalescing can use this mechanism, where multiple events sharing
+the same `datagram_id` indicate they were coalesced in the same UDP datagram.
+The selection of specific and locally-unique `datagram_id` values is an
+implementation choice.
 
 ## datagrams_received {#quic-datagramsreceived}
 


### PR DESCRIPTION
Fixes #370. 

This better explains the intent behind `is_coalesced` and also adds it to other events that *probably* should have it as well. 

I'm not sure anymore that this is the best design however, since there's a lot of duplication for a feature that isn't THAT important to track...

I wonder if we can get away with something like "If implementations don't want to track individual datagram IDs, but still want to indicate a packet was/could be coalesced, they can use datagram_id = -1 to indicate this" (and then of course we remove `is_coalesced` and make `datagram_id` an `int32` instead of `uint32`).

That would be a bit dirty... but reduce the confusion and duplication considerably? 