### PR TITLE
Add raw bytes field support to CONNECTION_CLOSE.

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2051,6 +2051,11 @@ error. For known frame types, the appropriate string value is used. For unknown
 frame types, the numerical value without variable-length integer encoding is
 used.
 
+The CONNECTION_CLOSE reason is a byte sequences, that may be possible to
+present as UTF-8. The `reason_text` and `reason_bytes` fields provide support
+for either format. Implementations SHOULD log at least one format, but MAY log
+both or none.
+
 ~~~ cddl
 ErrorSpace = "transport" /
              "application"
@@ -2062,7 +2067,8 @@ ConnectionCloseFrame = {
                   CryptoError /
                   $ApplicationError /
                   uint64
-    ? reason: text
+    ? reason_text: text
+    ? reason_bytes: hexstring
 
     ; when error_space === "transport"
     ? trigger_frame_type: uint64 /

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2052,7 +2052,7 @@ frame types, the numerical value without variable-length integer encoding is
 used.
 
 The CONNECTION_CLOSE reason is a byte sequences, that may be possible to
-present as UTF-8. The `reason_text` and `reason_bytes` fields provide support
+present as UTF-8. The `reason` and `reason_bytes` fields provide support
 for either format. Implementations SHOULD log at least one format, but MAY log
 both or none.
 
@@ -2067,7 +2067,7 @@ ConnectionCloseFrame = {
                   CryptoError /
                   $ApplicationError /
                   uint64
-    ? reason_text: text
+    ? reason: text
     ? reason_bytes: hexstring
 
     ; when error_space === "transport"

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2051,10 +2051,11 @@ error. For known frame types, the appropriate string value is used. For unknown
 frame types, the numerical value without variable-length integer encoding is
 used.
 
-The CONNECTION_CLOSE reason is a byte sequences, that may be possible to
-present as UTF-8. The `reason` and `reason_bytes` fields provide support
-for either format. Implementations SHOULD log at least one format, but MAY log
-both or none.
+The CONNECTION_CLOSE reason phrase is a byte sequences. It is likely that this
+sequence is presentable as UTF-8, in which case it can be logged in the `reason`
+field. The `reason_bytes` field supports logging the bytes, which can be useful
+when the value is not UTF-8 or when and endpoint does not want to decode it.
+Implementations SHOULD log at least one format, but MAY log both or none.
 
 ~~~ cddl
 ErrorSpace = "transport" /

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2053,8 +2053,8 @@ used.
 
 The CONNECTION_CLOSE reason phrase is a byte sequences. It is likely that this
 sequence is presentable as UTF-8, in which case it can be logged in the `reason`
-field. The `reason_bytes` field supports logging the bytes, which can be useful
-when the value is not UTF-8 or when and endpoint does not want to decode it.
+field. The `reason_bytes` field supports logging the raw bytes, which can be useful
+when the value is not UTF-8 or when an endpoint does not want to decode it.
 Implementations SHOULD log at least one format, but MAY log both or none.
 
 ~~~ cddl


### PR DESCRIPTION
Fixes #411

Same approach as the one we look for ALPNInformation. Allows endpoints to log either, because sometimes it is more useful to print and consume a string like "It's borked" than it's hex encoded equivalent.