### PR TITLE
Define extension schema policy and registry

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -95,7 +95,7 @@ implementation decision.
 
 # Overview
 
-This document describes how the QUIC protocol can be expressed in qlog. It
+This document describes how the HTTP/3 protocol can be expressed in qlog. It
 defines a qlog extension schema for use with the main schema {{QLOG-MAIN}}.
 HTTP/3 events are defined with a category, a name (the concatenation of
 "category" and "event"), an "importance", an optional "trigger", and "data"

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -50,9 +50,8 @@ informative:
 
 --- abstract
 
-This document describes concrete qlog event definitions and their metadata for
-HTTP/3-related events. These events can then be embedded in the higher
-level schema defined in {{QLOG-MAIN}}.
+This document defines a qlog extension schema containing concrete qlog event
+definitions and their metadata for HTTP/3-related events.
 
 --- note_Note_to_Readers
 
@@ -71,10 +70,12 @@ various programming languages can be found at
 
 # Introduction
 
-This document describes the values of the qlog name ("category" + "event") and
+This document defines a qlog extension schema ({{Section 9 of QLOG-MAIN}})
+containing concrete qlog event definitions and their metadata for HTTP/3-related
+events. Specifically, the values of the qlog name ("category" + "event") and
 "data" fields and their semantics for the HTTP/3 protocol {{RFC9114}} and some
-of extensions (see {{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}}
-and {{!H3-DATAGRAM=RFC9297}}).
+of it's extensions (see {{!EXTENDED-CONNECT=RFC9220}},
+{{!H3_PRIORITIZATION=RFC9218}} and {{!H3-DATAGRAM=RFC9297}}).
 
 ## Notational Conventions
 
@@ -94,10 +95,12 @@ implementation decision.
 
 # Overview
 
-This document describes how HTTP/3 can be expressed in qlog using the schema
-defined in {{QLOG-MAIN}}. HTTP/3 events are defined with a category, a name (the
-concatenation of "category" and "event"), an "importance", an optional
-"trigger", and "data" fields.
+This document defines a single event schema identified by the URI
+"urn:ietf:params:qlog:h3".
+
+HTTP/3 events are defined with a category, a name (the concatenation of
+"category" and "event"), an "importance", an optional "trigger", and "data"
+fields.
 
 Some data fields use complex datastructures. These are represented as enums or
 re-usable definitions, which are grouped together on the bottom of this document
@@ -105,6 +108,16 @@ for clarity.
 
 When any event from this document is included in a qlog trace, the
 "protocol_type" qlog array field MUST contain an entry with the value "HTTP3".
+
+## Draft Schema Identification
+
+Only implementations of the final, published RFC can use the schema identified
+by "urn:ietf:params:qlog:h3". Until such an RFC exists, implementations MUST NOT
+identify themselves using this URI.
+
+Implementations of draft versions of the extension schema MUST append the string
+"-" and the corresponding draft number to the URI. For example, draft 07 of this
+document is identified using the URI "urn:ietf:params:qlog:h3-07".
 
 ## Usage with QUIC
 
@@ -120,9 +133,9 @@ identifier, potentially suffixed by the vantagepoint type (For example,
 abcd1234_server.qlog would contain the server-side trace of the connection with
 GUID abcd1234).
 
-# HTTP/3 Event Overview
+# Event Overview
 
-This document defines events in two categories, written as lowercase to follow
+This document defines a single category of events, written as lowercase to follow
 convention: h3 ({{h3-ev}}).
 
 As described in {{Section 3.4.2 of QLOG-MAIN}}, the qlog "name" field is the

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -74,7 +74,7 @@ This document defines a qlog extension schema ({{Section 9 of QLOG-MAIN}})
 containing concrete qlog event definitions and their metadata for HTTP/3-related
 events. Specifically, the values of the qlog name ("category" + "event") and
 "data" fields and their semantics for the HTTP/3 protocol {{RFC9114}} and some
-of it's extensions (see {{!EXTENDED-CONNECT=RFC9220}},
+of its extensions (see {{!EXTENDED-CONNECT=RFC9220}},
 {{!H3_PRIORITIZATION=RFC9218}} and {{!H3-DATAGRAM=RFC9297}}).
 
 ## Notational Conventions

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -71,11 +71,11 @@ various programming languages can be found at
 # Introduction
 
 This document defines a qlog extension schema ({{Section 9 of QLOG-MAIN}})
-containing concrete qlog event definitions and their metadata for HTTP/3-related
-events. Specifically, the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the HTTP/3 protocol {{RFC9114}} and some
-of its extensions (see {{!EXTENDED-CONNECT=RFC9220}},
-{{!H3_PRIORITIZATION=RFC9218}} and {{!H3-DATAGRAM=RFC9297}}).
+containing concrete qlog event definitions related to HTTP/3. Specifically, the
+values of the qlog name ("category" + "event") and "data" fields and their
+semantics for the HTTP/3 protocol {{RFC9114}} and some of its extensions (see
+{{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}} and
+{{!H3-DATAGRAM=RFC9297}}).
 
 ## Notational Conventions
 
@@ -95,12 +95,12 @@ implementation decision.
 
 # Overview
 
-This document defines a single event schema identified by the URI
-"urn:ietf:params:qlog:h3".
-
+This document describes how the QUIC protocol can be expressed in qlog. It
+defines a qlog extension schema for use with the main schema {{QLOG-MAIN}}.
 HTTP/3 events are defined with a category, a name (the concatenation of
 "category" and "event"), an "importance", an optional "trigger", and "data"
-fields.
+fields.  The schema is identified by the URI "urn:ietf:params:qlog:h3", it
+contains a category identifier "h3".
 
 Some data fields use complex datastructures. These are represented as enums or
 re-usable definitions, which are grouped together on the bottom of this document
@@ -118,6 +118,8 @@ identify themselves using this URI.
 Implementations of draft versions of the extension schema MUST append the string
 "-" and the corresponding draft number to the URI. For example, draft 07 of this
 document is identified using the URI "urn:ietf:params:qlog:h3-07".
+
+The category name is not affected by this requirement.
 
 ## Usage with QUIC
 
@@ -676,6 +678,9 @@ identifer" registry.
 
 Extension URI:
 : urn:ietf:params:qlog:h3
+
+Category Identifier(s):
+: h3
 
 Description:
 : Event definitions related to the HTTP/3 application protocol.

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -658,7 +658,17 @@ document as well.
 
 # IANA Considerations
 
-There are no IANA considerations.
+This document registers a new entry in the "qlog event extension schema
+identifer" registry.
+
+Extension URI:
+: urn:ietf:params:qlog:h3
+
+Description:
+: Event definitions related to the HTTP/3 application protocol.
+
+Reference:
+: This Document.
 
 --- back
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1146,14 +1146,14 @@ SimulationMarker = {
 # Event extensibility {#event-extensibility}
 
 The main qlog schema defined by this document describes log and trace formats
-that have related events. A minimal set of common events are presented in
+that have related events. A minimal set of common events is presented in
 {{events}}. It is expected that logging is extended with specific, per-protocol
 event definitions that specify the name (category + type) and data needed for
 each individual event. Examples include the QUIC event definitions {{QLOG-QUIC}}
 and HTTP/3 event definitions {{QLOG-H3}}.
 
 New event definitions SHOULD follow the guidance in this section, which provides
-consistency that makes it easier for qlog implementers to support a wide variety
+consistency measures that make it easier for qlog implementers to support a wide variety
 of protocols.
 
 ## Extended Event Schema
@@ -1172,8 +1172,8 @@ Implementations that might record events from extension schemas SHOULD list all
 category identifiers in use. This is achieved by including the appropriate URI
 in the `additional_event_schemas` field of the QlogFile ({{qlog-file-schema}})
 or QlogFileSeq ({{qlog-file-seq-schema}}). The `additional_event_schema` is a
-hint to tools about the possible events that a qlog file might contain. The file
-may contain events that do not belong to a listed category identifier. Tools
+hint to tools about the possible event categories (and event types contained therein) that a qlog file might contain. The file
+may contain event types that do not belong to a listed category identifier. Tools
 MUST NOT treat this as an error; see {{tooling}}.
 
 Each extension schema is named by a URI. That URI MUST be absolute and MUST
@@ -1183,7 +1183,7 @@ after a "#" in the URI).
 For extension schema defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
-Private or non-standard extension schema a can use other URI formats. URIs that
+Private or non-standard extension schema can use other URI formats. URIs that
 contain a domain name SHOULD also contain a month-date in the form mmyyyy. The
 definition of the schema and assignment of the URI MUST have been authorized by
 the owner of the domain name on or very close to that date. (This avoids

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1159,34 +1159,51 @@ of protocols.
 ## Extended Event Schema
 
 New event definitions SHOULD be part of an extension schema, using the
-annotations and concepts presented in this section. Events can be grouped
-together into a category but cannot belong to multiple categories. A schema
-defines one or more qlog event categories.
+annotations and concepts presented in this section.
+
+A schema defines one or more qlog event categories that can contain multiple
+event definitions. Each event MUST only belong to a single category.
+
+It is not possible to extend a category with new events. Instead, extension
+schema MUST define new categories with globally unique identifiers. Per
+{{{#name-field}}}, event names are the concatenation of category and type.
+Therefore, unique category identifiers ensure events in qlog files are
+disambuiguated.
 
 Each extension schema is named by a URI. That URI MUST be absolute; it precisely
 identifies the format and meaning of the extension. URIs that contain a domain
 name SHOULD also contain a month-date in the form mmyyyy. The definition of the
 schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain
-names change ownership.) If the resource or document defines several categories,
-then the URI MUST identify the actual extension in use, e.g., using a fragment
-or query identifier (characters after a "#" or "?" in the URI).
+names change ownership.) If the resource or document defines several event
+categories, then the URI MUST identify the actual category in use, e.g., using
+a fragment or query identifier (characters after a "#" or "?" in the URI).
 
 For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
-A log file that that uses events from extension schema SHOULD list all schema
-identifiers in the `additional_event_schemas` field.
+A log file that uses events from extension schema SHOULD list all schema
+identifiers in the `additional_event_schemas` field; see {{qlog-file-schema}}
+and {{qlog-file-seq-schema}}.
 
-For example, a qlog file that uses two hypothetical standard qlog extension
-schema named "rick" and "morty", along with a private extension named "pickle"
-would indicate this as:
+In the following example, a qlog file contains two hypothetical standardized
+extension schema, along with a private extension. The first schema is named
+"rick" and consists of categories "roll", "astley", and "moranis". The second
+schema is named "john" and consists of categories "doe", "candy", and "goodman".
+The private schema is named "pickle" and consists of categories "pepper",
+"lilly", and "rick":
 
 ~~~
 additional_event_schemas = [
-                            urn:ietf:params:qlog:rick,
-                            urn:ietf:params:qlog:morty,
-                            https://example.com/032024/pickle.html#me
+                            urn:ietf:params:qlog:rick#roll,
+                            urn:ietf:params:qlog:rick#astley,
+                            urn:ietf:params:qlog:rick#moranis,
+                            urn:ietf:params:qlog:john#doe,
+                            urn:ietf:params:qlog:john#candy,
+                            urn:ietf:params:qlog:john#goodman,
+                            https://example.com/032024/pickle.html#pepper,
+                            https://example.com/032024/pickle.html#lilly,
+                            https://example.com/032024/pickle.html#rick,
                           ]
 ~~~
 
@@ -1691,23 +1708,29 @@ IANA is requested to create the "qlog event extension schema identifer" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
 event extension schema. It has the following format:
 
-| Extension URI | Description | Reference |
-|||
+| Extension URI | Categor Identifier(s) | Description | Reference |
+||||
 
 No entries are registered by this document.
 
 The registry operates under the Expert Review policy, per {{Section 4.5 of
 !RFC8126}}.  When reviewing requests, the expert SHOULD check that the guidance
 in {{event-extensibility}} and in {{privacy}} has been duly considered. However,
-the outcome of this check cannot be used as a basis for rejection. The expert
-SHOULD also check that the request URI is appropriate to the extension and
+the outcome of this check cannot be used as a basis for rejection.
+
+The expert SHOULD check that the request URI is appropriate to the extension and
 unique, including determining if the number of requested URIs are proportional
-to the number of extension points.
+to the number of extension points.  The expert MUST check that category
+identifiers are unique. Non-unique URI or category names are sufficent grounds
+for rejection.
 
 Registration requests should use the following template:
 
 Extension URI:
-: \[The extension identifier\]
+: \[the extension schema identifier\]
+
+Category identifiers:
+: \[a comma-seperated list of the full set of categories belonging to the schema\]
 
 Description:
 : \[a description of the extension schema\]

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1178,7 +1178,7 @@ For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 A log file that that uses events from extension schema SHOULD list all schema
 identifiers in the `additional_event_schemas` field.
 
-For example, a qlog file that uses three hypothetical standard qlog extension
+For example, a qlog file that uses two hypothetical standard qlog extension
 schema named "rick" and "morty", along with a private extension named "pickle"
 would indicate this as:
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1695,13 +1695,13 @@ event extension schema. It has the following format:
 
 No entries are registered by this document.
 
-The registry operates under the Expert Review policy, per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert SHOULD check that:
-
-: The guidance in {{event-extensibility}} and in {{privacy}} has been duly
-considered. However, the outcome of this check cannot be used as a basis for
-rejection.
-
-: The request URI is appropriate to the extension and unique.
+The registry operates under the Expert Review policy, per {{Section 4.5 of
+!RFC8126}}.  When reviewing requests, the expert SHOULD check that the guidance
+in {{event-extensibility}} and in {{privacy}} has been duly considered. However,
+the outcome of this check cannot be used as a basis for rejection. The expert
+SHOULD also check that the request URI is appropriate to the extension and
+unique, including determining if the number of requested URIs are proportional
+to the number of extension points.
 
 Registration requests should use the following template:
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1723,7 +1723,8 @@ Universities.
 
 Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
 Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, Christian Huitema and Hugo Landau for their feedback and suggestions.
+Yamamoto, Christian Huitema, Hugo Landau, and Jonathan Lennow for their feedback
+and suggestions.
 
 # Change Log
 {:numbered="false" removeinrfc="true"}

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1170,8 +1170,7 @@ schemas MUST define new categories with globally unique identifiers. Per
 Therefore, unique category identifiers ensure events in qlog files are
 disambuiguated.
 
-Each extension schema is named by a URI. That URI MUST be absolute; it precisely
-identifies the format and meaning of the extension. URIs that contain a domain
+Each extension schema is named by a URI. That URI MUST be absolute. URIs that contain a domain
 name SHOULD also contain a month-date in the form mmyyyy. The definition of the
 schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1176,8 +1176,8 @@ name SHOULD also contain a month-date in the form mmyyyy. The definition of the
 schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain
 names change ownership.) If the extension schema contains several event
-categories, then the URI MUST identify the actual category in use, e.g., using
-a fragment or query identifier (characters after a "#" or "?" in the URI).
+categories, then the URI MUST identify the actual category in use using
+a fragment identifier (characters after a "#" in the URI).
 
 For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1166,7 +1166,7 @@ defines one or more qlog event categories.
 Each extension schema is named by a URI. That URI MUST be absolute; it precisely
 identifies the format and meaning of the extension. URIs that contain a domain
 name SHOULD also contain a month-date in the form mmyyyy. The definition of the
-element and assignment of the URI MUST have been authorized by the owner of the
+schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain
 names change ownership.) If the resource or document defines several categories,
 then the URI MUST identify the actual extension in use, e.g., using a fragment

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -215,7 +215,7 @@ component traces, defined in {{qlog-file-def}} as:
 QlogFile = {
     qlog_version: text
     ? qlog_format: text .default "JSON"
-    ? additional_event_schema: [+ text]
+    ? additional_event_schemas: [+ text]
     ? title: text
     ? description: text
     ? traces: [+ Trace /
@@ -231,7 +231,7 @@ MUST either be one of the options defined in this document (i.e.,
 {{concrete-formats}}) or the field MUST be omitted entirely. When the field is
 omitted the default value of "JSON" applies.
 
-The optional "additional_event_schema" field is described in {{event-extensibility}}.
+The optional "additional_event_schemas" field is described in {{event-extensibility}}.
 
 The optional "title" and "description" fields provide additional free-text
 information about the file.
@@ -372,7 +372,7 @@ of component traces, defined in {{qlog-file-def}} as:
 QlogFileSeq = {
     qlog_format: "JSON-SEQ"
     qlog_version: text
-    ? additional_event_schema: [+ text]
+    ? additional_event_schemas: [+ text]
     ? title: text
     ? description: text
     trace: TraceSeq
@@ -384,7 +384,7 @@ The required "qlog_format" field MUST have the value "JSON-SEQ".
 
 The required "qlog_version" field MUST have the value "0.4".
 
-The optional "additional_event_schema" field is described in {{event-extensibility}}.
+The optional "additional_event_schemas" field is described in {{event-extensibility}}.
 
 The optional "title" and "description" fields provide additional free-text
 information about the file.
@@ -1175,15 +1175,17 @@ For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
 A log file that that uses events from extension schema SHOULD list all schema
-identifiers in the `additional_event_schema` field.
+identifiers in the `additional_event_schemas` field.
 
-For example, a qlog file that uses two hypothetical qlog extension schema named
-"rick" and "morty" would indicate this as:
+For example, a qlog file that uses three hypothetical standard qlog extension
+schema named "rick" and "morty", along with a private extension named "pickle"
+would indicate this as:
 
 ~~~
-additional_event_schema = [
+additional_event_schemas = [
                             urn:ietf:params:qlog:rick,
-                            urn:ietf:params:qlog:morty
+                            urn:ietf:params:qlog:morty,
+                            https://example.com/032024/pickle.html#me
                           ]
 ~~~
 
@@ -1693,8 +1695,7 @@ event extension schema. It has the following format:
 
 No entries are registered by this document.
 
-The registry operates under the Expert Review policy, per {{Section 4.5 of
-!RFC8126}}.  When reviewing requests, the expert SHOULD check that:
+The registry operates under the Expert Review policy, per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert SHOULD check that:
 
 : The guidance in {{event-extensibility}} and in {{privacy}} has been duly
 considered. However, the outcome of this check cannot be used as a basis for

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1172,7 +1172,7 @@ e.g., using a fragment or query identifier (characters after a "#" or "?" in the
 URI).
 
 For extensions defined in RFCs, the URI used SHOULD be a URN starting with
-`urn:ietf:params:qlog` followed by a registered, descriptive name.
+`urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
 A log file that that uses events from extension schema SHOULD list all schema
 identifiers in the `additional_event_schema` field.
@@ -1723,7 +1723,7 @@ Universities.
 
 Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
 Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, Christian Huitema, Hugo Landau, and Jonathan Lennow for their feedback
+Yamamoto, Christian Huitema, Hugo Landau, and Jonathan Lennox for their feedback
 and suggestions.
 
 # Change Log

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -215,6 +215,7 @@ component traces, defined in {{qlog-file-def}} as:
 QlogFile = {
     qlog_version: text
     ? qlog_format: text .default "JSON"
+    ? additional_event_schema: [+ text]
     ? title: text
     ? description: text
     ? traces: [+ Trace /
@@ -229,6 +230,8 @@ The optional "qlog_format" field indicates the serialization format. Its value
 MUST either be one of the options defined in this document (i.e.,
 {{concrete-formats}}) or the field MUST be omitted entirely. When the field is
 omitted the default value of "JSON" applies.
+
+The optional "additional_event_schema" field is described in {{event-extensibility}}.
 
 The optional "title" and "description" fields provide additional free-text
 information about the file.
@@ -369,6 +372,7 @@ of component traces, defined in {{qlog-file-def}} as:
 QlogFileSeq = {
     qlog_format: "JSON-SEQ"
     qlog_version: text
+    ? additional_event_schema: [+ text]
     ? title: text
     ? description: text
     trace: TraceSeq
@@ -379,6 +383,8 @@ QlogFileSeq = {
 The required "qlog_format" field MUST have the value "JSON-SEQ".
 
 The required "qlog_version" field MUST have the value "0.4".
+
+The optional "additional_event_schema" field is described in {{event-extensibility}}.
 
 The optional "title" and "description" fields provide additional free-text
 information about the file.
@@ -1137,18 +1143,52 @@ SimulationMarker = {
 ~~~
 {: #simulation-marker-def title="SimulationMarker definition"}
 
-# Event definition guidelines
+# Event extensibility {#event-extensibility}
 
-This document defines the main schema for the qlog format together with some
-common events, which on their own do not provide much logging utility. It is
-expected that logging is extended with specific, per-protocol event definitions
-that specify the name (category + type) and data needed for each individual
-event. Examples include the QUIC event definitions {{QLOG-QUIC}} and HTTP/3
-event definitions {{QLOG-H3}}.
+The main qlog schema defined by this document describes log and trace formats
+that have related events. A minimal set of common events are presented in
+{{events}}. It is expected that logging is extended with specific, per-protocol
+event definitions that specify the name (category + type) and data needed for
+each individual event. Examples include the QUIC event definitions {{QLOG-QUIC}}
+and HTTP/3 event definitions {{QLOG-H3}}.
 
-This section defines some basic annotations and concepts that SHOULD be used by
-event definition documents. Doing so ensures a measure of consistency that makes
-it easier for qlog implementers to support a wide variety of protocols.
+New event definitions SHOULD follow the guidance in this section, which provides
+consistency that makes it easier for qlog implementers to support a wide variety
+of protocols.
+
+## Extended Event Schema
+
+New events SHOULD be defined using an extension schema, using the annotations
+and concepts presented in this section.
+
+Each extension schema is named by a URI. That URI MUST be absolute; it precisely
+identifies the format and meaning of the extension. URIs that contain a domain
+name SHOULD also contain a month-date in the form mmyyyy. The definition of the
+element and assignment of the URI MUST have been authorized by the owner of the
+domain name on or very close to that date. (This avoids problems when domain
+names change ownership.) If the resource or document defines several categories
+or groups of events, then the URI MUST identify the actual extension in use,
+e.g., using a fragment or query identifier (characters after a "#" or "?" in the
+URI).
+
+For extensions defined in RFCs, the URI used SHOULD be a URN starting with
+`urn:ietf:params:qlog` followed by a registered, descriptive name.
+
+A log file that that uses events from extension schema SHOULD list all schema
+identifiers in the `additional_event_schema` field.
+
+For example, a qlog file that uses two hypothetical qlog extension schema named
+"rick" and "morty" would indicate this as:
+
+~~~
+additional_event_schema = [
+                            urn:ietf:params:qlog:rick,
+                            urn:ietf:params:qlog:morty
+                          ]
+~~~
+
+The registration requirements for extension schema identifiers are detailed in
+{{iana}}.
 
 ## Event design
 
@@ -1629,9 +1669,49 @@ The most sensitive data in qlog is typically contained in RawInfo type fields
 (see {{raw-info}}). Therefore, qlog users should exercise caution and limit the
 inclusion of such fields for all but the most stringent use cases.
 
-# IANA Considerations
+# IANA Considerations {#iana}
 
-There are no IANA considerations.
+IANA is requested to register a new entry in the "IETF URN Sub-namespace for
+Registered Protocol Parameter Identifiers" registry ({{!RFC3553}})":
+
+Registered Parameter Identifier:
+: qlog
+
+Reference:
+: This Document
+
+IANA Registry Reference:
+: [](https://www.iana.org/assignments/qlog){: brackets="angle"}
+
+
+IANA is requested to create the "qlog event extension schema identifer" registry
+at [](https://www.iana.org/assignments/qlog) for the purpose of registering
+event extension schema. It has the following format:
+
+| Extension URI | Description | Reference |
+|||
+
+No entries are registered by this document.
+
+The registry operates under the Expert Review policy, per {{Section 4.5 of
+!RFC8126}}.  When reviewing requests, the expert SHOULD check that:
+
+: The guidance in {{event-extensibility}} and in {{privacy}} has been duly
+considered. However, the outcome of this check cannot be used as a basis for
+rejection.
+
+: The request URI is appropriate to the extension and unique.
+
+Registration requests should use the following template:
+
+Extension URI:
+: \[The extension identifier\]
+
+Description:
+: \[a description of the extension schema\]
+
+Reference:
+: \[to a specification defining the schema\]
 
 --- back
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1161,29 +1161,33 @@ of protocols.
 New event definitions SHOULD be part of an extension schema, using the
 annotations and concepts presented in this section.
 
-An extension schema defines one or more qlog event categories that can contain multiple
-event definitions. Each event MUST only belong to a single category.
-
-It is not possible to extend a category with new events. Instead, extension
-schemas MUST define new categories with globally unique identifiers. Per
+An extension schema defines one or more qlog event categories that can contain
+multiple event definitions. Each category MUST have a globally unique category
+identifier. Each event MUST only belong to a single category. Per
 {{{#name-field}}}, event names are the concatenation of category and type.
-Therefore, unique category identifiers ensure events in qlog files are
-disambuiguated.
+Therefore, these requirements ensure there are no ambiguities when multiple
+extension schema are in use.
 
-Each extension schema is named by a URI. That URI MUST be absolute. URIs that contain a domain
-name SHOULD also contain a month-date in the form mmyyyy. The definition of the
-schema and assignment of the URI MUST have been authorized by the owner of the
-domain name on or very close to that date. (This avoids problems when domain
-names change ownership.) If the extension schema contains several event
-categories, then the URI MUST identify the actual category in use using
-a fragment identifier (characters after a "#" in the URI).
+Implementations that might record events from extension schemas SHOULD list all
+category identifiers in use. This is achieved by including the appropriate URI
+in the `additional_event_schemas` field of the QlogFile ({{qlog-file-schema}})
+or QlogFileSeq ({{qlog-file-seq-schema}}). The `additional_event_schema` is a
+hint to tools about the possible events that a qlog file might contain. The file
+may contain events that do not belong to a listed category identifier. Tools
+MUST NOT treat this as an error; see {{tooling}}.
 
-For extensions defined in RFCs, the URI used SHOULD be a URN starting with
+Each extension schema is named by a URI. That URI MUST be absolute and MUST
+include a category identifier, indicated using a fragment identifier (characters
+after a "#" in the URI).
+
+For extension schema defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
-A log file that uses events from extension schemas SHOULD list all extension schema
-identifiers in the `additional_event_schemas` field; see {{qlog-file-schema}}
-and {{qlog-file-seq-schema}}.
+Private or non-standard extension schema a can use other URI formats. URIs that
+contain a domain name SHOULD also contain a month-date in the form mmyyyy. The
+definition of the schema and assignment of the URI MUST have been authorized by
+the owner of the domain name on or very close to that date. (This avoids
+problems when domain names change ownership.)
 
 In the following example, a qlog file contains events defined in two hypothetical standardized
 extension schema, along with a private extension. The first schema is named
@@ -1207,7 +1211,7 @@ The private schema is named "pickle" and consists of categories "pepper",
 ~~~
 {: #additional-event-schema-ex title="Example of using the additional-event-schema field"}
 
-The registration requirements for extension schema identifiers are detailed in
+The registration requirements for extension schema URIs are detailed in
 {{iana}}.
 
 ## Event design
@@ -1704,7 +1708,7 @@ IANA Registry Reference:
 : [](https://www.iana.org/assignments/qlog){: brackets="angle"}
 
 
-IANA is requested to create the "qlog event extension schema identifer" registry
+IANA is requested to create the "qlog event extension schema URI" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
 event extension schema. It has the following format:
 
@@ -1718,7 +1722,7 @@ The registry operates under the Expert Review policy, per {{Section 4.5 of
 in {{event-extensibility}} and in {{privacy}} has been duly considered. However,
 the outcome of this check cannot be used as a basis for rejection.
 
-The expert SHOULD check that the request URI is appropriate to the extension and
+The expert SHOULD check that the requested URI is appropriate to the extension and
 unique, including determining if the number of requested URIs are proportional
 to the number of extension points.  The expert MUST check that category
 identifiers are unique. Non-unique URI or category names are sufficent grounds

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1158,18 +1158,19 @@ of protocols.
 
 ## Extended Event Schema
 
-New events SHOULD be defined using an extension schema, using the annotations
-and concepts presented in this section.
+New event definitions SHOULD be part of an extension schema, using the
+annotations and concepts presented in this section. Events can be grouped
+together into a category but cannot belong to multiple categories. A schema
+defines one or more qlog event categories.
 
 Each extension schema is named by a URI. That URI MUST be absolute; it precisely
 identifies the format and meaning of the extension. URIs that contain a domain
 name SHOULD also contain a month-date in the form mmyyyy. The definition of the
 element and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain
-names change ownership.) If the resource or document defines several categories
-or groups of events, then the URI MUST identify the actual extension in use,
-e.g., using a fragment or query identifier (characters after a "#" or "?" in the
-URI).
+names change ownership.) If the resource or document defines several categories,
+then the URI MUST identify the actual extension in use, e.g., using a fragment
+or query identifier (characters after a "#" or "?" in the URI).
 
 For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1161,11 +1161,11 @@ of protocols.
 New event definitions SHOULD be part of an extension schema, using the
 annotations and concepts presented in this section.
 
-A schema defines one or more qlog event categories that can contain multiple
+An extension schema defines one or more qlog event categories that can contain multiple
 event definitions. Each event MUST only belong to a single category.
 
 It is not possible to extend a category with new events. Instead, extension
-schema MUST define new categories with globally unique identifiers. Per
+schemas MUST define new categories with globally unique identifiers. Per
 {{{#name-field}}}, event names are the concatenation of category and type.
 Therefore, unique category identifiers ensure events in qlog files are
 disambuiguated.
@@ -1175,18 +1175,18 @@ identifies the format and meaning of the extension. URIs that contain a domain
 name SHOULD also contain a month-date in the form mmyyyy. The definition of the
 schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. (This avoids problems when domain
-names change ownership.) If the resource or document defines several event
+names change ownership.) If the extension schema contains several event
 categories, then the URI MUST identify the actual category in use, e.g., using
 a fragment or query identifier (characters after a "#" or "?" in the URI).
 
 For extensions defined in RFCs, the URI used SHOULD be a URN starting with
 `urn:ietf:params:qlog:` followed by a registered, descriptive name.
 
-A log file that uses events from extension schema SHOULD list all schema
+A log file that uses events from extension schemas SHOULD list all extension schema
 identifiers in the `additional_event_schemas` field; see {{qlog-file-schema}}
 and {{qlog-file-seq-schema}}.
 
-In the following example, a qlog file contains two hypothetical standardized
+In the following example, a qlog file contains events defined in two hypothetical standardized
 extension schema, along with a private extension. The first schema is named
 "rick" and consists of categories "roll", "astley", and "moranis". The second
 schema is named "john" and consists of categories "doe", "candy", and "goodman".
@@ -1194,18 +1194,19 @@ The private schema is named "pickle" and consists of categories "pepper",
 "lilly", and "rick":
 
 ~~~
-additional_event_schemas = [
-                            urn:ietf:params:qlog:rick#roll,
-                            urn:ietf:params:qlog:rick#astley,
-                            urn:ietf:params:qlog:rick#moranis,
-                            urn:ietf:params:qlog:john#doe,
-                            urn:ietf:params:qlog:john#candy,
-                            urn:ietf:params:qlog:john#goodman,
-                            https://example.com/032024/pickle.html#pepper,
-                            https://example.com/032024/pickle.html#lilly,
-                            https://example.com/032024/pickle.html#rick,
+"additional_event_schemas": [
+                            "urn:ietf:params:qlog:rick#roll",
+                            "urn:ietf:params:qlog:rick#astley",
+                            "urn:ietf:params:qlog:rick#moranis",
+                            "urn:ietf:params:qlog:john#doe",
+                            "urn:ietf:params:qlog:john#candy",
+                            "urn:ietf:params:qlog:john#goodman",
+                            "https://example.com/032024/pickle.html#pepper",
+                            "https://example.com/032024/pickle.html#lilly",
+                            "https://example.com/032024/pickle.html#rick",
                           ]
 ~~~
+{: #additional-event-schema-ex title="Example of using the additional-event-schema field"}
 
 The registration requirements for extension schema identifiers are detailed in
 {{iana}}.
@@ -1708,7 +1709,7 @@ IANA is requested to create the "qlog event extension schema identifer" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
 event extension schema. It has the following format:
 
-| Extension URI | Categor Identifier(s) | Description | Reference |
+| Extension URI | Category Identifier(s) | Description | Reference |
 ||||
 
 No entries are registered by this document.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2170,7 +2170,17 @@ document as well.
 
 # IANA Considerations
 
-There are no IANA considerations.
+This document registers a new entry in the "qlog event extension schema
+identifer" registry.
+
+Extension URI:
+: urn:ietf:params:qlog:quic
+
+Description:
+: Event definitions related to the QUIC transport protocol.
+
+Reference:
+: This Document.
 
 --- back
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -65,11 +65,12 @@ various programming languages can be found at
 
 # Introduction
 
-This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the QUIC protocol (see
-{{!QUIC-TRANSPORT=RFC9000}}, {{!QUIC-RECOVERY=RFC9002}}, and
-{{!QUIC-TLS=RFC9001}}) and some of its extensions (see
-{{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
+This document defines a qlog extension schema ({{Section 9 of QLOG-MAIN}})
+containing concrete qlog event definitions related to QUIC. Specifically, the
+values of the qlog name ("category" + "event") and "data" fields and their
+semantics for the QUIC protocol (see {{!QUIC-TRANSPORT=RFC9000}},
+{{!QUIC-RECOVERY=RFC9002}}, and {{!QUIC-TLS=RFC9001}}) and some of its
+extensions (see {{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
 
 ## Notational Conventions
 
@@ -89,10 +90,13 @@ implementation decision.
 
 # Overview
 
-This document describes how the QUIC protocol can be expressed in qlog using
-the schema defined in {{QLOG-MAIN}}. QUIC protocol events are defined with a
-category, a name (the concatenation of "category" and "event"), an "importance",
-an optional "trigger", and "data" fields.
+This document describes how the QUIC protocol can be expressed in qlog. It
+defines a qlog extension schema for use with the main schema {{QLOG-MAIN}}. QUIC
+protocol events are defined with a category, a name (the concatenation of
+"category" and "event"), an "importance", an optional "trigger", and "data"
+fields. The schema is identified by the URI "urn:ietf:params:qlog:quic", that
+contains the following category identifiers: "connectivity", "quic", "security",
+and "recovery".
 
 Some data fields use complex datastructures. These are represented as enums or
 re-usable definitions, which are grouped together on the bottom of this document
@@ -2175,6 +2179,9 @@ identifer" registry.
 
 Extension URI:
 : urn:ietf:params:qlog:quic
+
+Category Identifier(s):
+: connectivity, quic, security, recovery
 
 Description:
 : Event definitions related to the QUIC transport protocol.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -94,7 +94,7 @@ This document describes how the QUIC protocol can be expressed in qlog. It
 defines a qlog extension schema for use with the main schema {{QLOG-MAIN}}. QUIC
 protocol events are defined with a category, a name (the concatenation of
 "category" and "event"), an "importance", an optional "trigger", and "data"
-fields. The schema is identified by the URI "urn:ietf:params:qlog:quic", that
+fields. The schema is identified by the URI "urn:ietf:params:qlog:quic", it
 contains the following category identifiers: "connectivity", "quic", "security",
 and "recovery".
 


### PR DESCRIPTION
Alternative to #284.

This follows Lennox's suggestion to take influence from RFC 8285 and reference
extension schema according to a URI. IETF documents can use URNs under a formal
namespace, and as such we register a new `qlog` URN Sub-namespace for
Registered Protocol Parameter Identifiers.

Fixes #283