### PR TITLE
Add extensibility for all events and official extension points

### DIFF
--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -73,7 +73,7 @@ function generate_aux_object() {
     done
     echo -e "}\n" >> $tmpfile
 
-    # generate dummy extension data for the sockets
+    # generate sample extension data for the sockets
     for socket in ${all_group_sockets}; do
       # to test if the setup works, replace the next line with an empty echo; 
       # you should see cddl errors :)

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -21,7 +21,7 @@ function extract_cddl() {
 
 # Prepend an object with all the unused types to a CDDL file
 # This makes sure there is at least 1 instance of each type to be checked by the cddl tool
-# Additionally, this generates dummy extensions for type and group sockets defined
+# Additionally, this generates sample extensions for type and group sockets defined
 # This is especially useful for extension points that are defined, but not yet exercised in the current set of documents
 # $1: the input (.cddl) file name
 function generate_aux_object() {

--- a/cddl_validate.sh
+++ b/cddl_validate.sh
@@ -20,10 +20,43 @@ function extract_cddl() {
 }
 
 # Prepend an object with all the unused types to a CDDL file
-# $1: the input (.cddl) file
+# This makes sure there is at least 1 instance of each type to be checked by the cddl tool
+# Additionally, this generates dummy extensions for type and group sockets defined
+# This is especially useful for extension points that are defined, but not yet exercised in the current set of documents
+# $1: the input (.cddl) file name
 function generate_aux_object() {
+
+    # There are two types of socket extensions: group and type sockets
+    # - Group sockets are used to extend existing types with new fields
+    # - Type sockets are used to make dynamic lists/ENUMs of types 
+    # We want to extract both so we can generate some random extension values for them 
+    # to make sure the extension points are usable by future documents
+
+    # the group socket extensions look like this   
+    # * $$extension-name
+    # nicely on their own row and everything :) so we extract rows that start like that,
+    # and then discard the * with regex groups, since we won't need it.
+    all_group_sockets=$(awk '/\* (\$\$.+)/ {print $2}' "$1")
+
+    # the type sockets are a bit more involved, usually looking like this
+    # $socket-name /= some-value / some-other-value
+    # we need to extract just the first part (excluding the /=)
+    all_type_sockets=$(awk '/.+ \/=/ {print $1}' "$1")
+
+    # we need to remove the * from before the group sockets
+    # in CDDL, the * indicates it's 0 or more
+    # this is intentional, as most group sockets aren't used in the current documents, and so 0 is accurate
+    # however, to force checking for correct use of the extension, we want the CDDL tool to act as if at least 1 is required
+    # we get this by removing the *, so it is forced to look for an actual use of the extension point (which we generate later)
+    original_cddl=`cat $1`
+    orig="\* \$\$"
+    target="\$\$"
+    force_group_sockets_cddl="${original_cddl//${orig}/${target}}" # // replaces ALL occurrences
+    echo "${force_group_sockets_cddl}" > $1
+
     # Generate the list of Unused types
     unused_types=$(cddl $1 generate 2>&1 | grep Unused | cut -d " " -f 4)
+
     # Create an object with all the unused types
     tmpfile=$(mktemp)
     echo "AuxObjectWithAllTypesForValidationOnly = {" >> $tmpfile
@@ -39,6 +72,20 @@ function generate_aux_object() {
       fi
     done
     echo -e "}\n" >> $tmpfile
+
+    # generate dummy extension data for the sockets
+    for socket in ${all_group_sockets}; do
+      # to test if the setup works, replace the next line with an empty echo; 
+      # you should see cddl errors :)
+      echo "  ${socket} //= ( new_field_name_test_$RANDOM: text )" >> $tmpfile
+    done
+
+    for socket in ${all_type_sockets}; do
+      # to test if the setup works, search for "new_type_test" in the json output
+      # it's a bit random (since the generator can also choose the "real" values if the type socket is being used)
+      # but there should be some instances of this in there as well (esp. for ProtocolType in practice)
+      echo "  ${socket} /= \"new_type_test_$RANDOM\"" >> $tmpfile
+    done
 
     tmpfile2=$(mktemp)
     cat $tmpfile $1 > $tmpfile2

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -146,7 +146,10 @@ in this specification.
 
 # HTTP/3 Events {#h3-ev}
 
-HTTP/3 events extend the `$ProtocolEventData` extension point defined in {{QLOG-MAIN}}.
+HTTP/3 events extend the `$ProtocolEventData` extension point defined in
+{{QLOG-MAIN}}. Additionally, they allow for direct extensibility by their use of
+per-event extension points via the `$$` CDDL "group socket" syntax, as also
+described in {{QLOG-MAIN}}.
 
 ~~~ cddl
 H3EventData = H3ParametersSet /
@@ -436,8 +439,9 @@ Owner = "local" /
 
 ## H3Frame
 
-The generic `$H3Frame` is defined here as a CDDL extension point (a "socket"
-or "plug"). It can be extended to support additional HTTP/3 frame types.
+The generic `$H3Frame` is defined here as a CDDL extension point (a "type
+socket" or "type plug"). It can be extended to support additional HTTP/3 frame
+types.
 
 ~~~ cddl
 ; The H3Frame is any key-value map (e.g., JSON object)
@@ -466,9 +470,10 @@ $H3Frame /= H3BaseFrames
 
 ## H3Datagram
 
-The generic `$H3Datagram` is defined here as a CDDL extension point (a "socket"
-or "plug"). It can be extended to support additional HTTP/3 datagram types. This
-document intentionally does not define any specific HTTP/3 Datagram types.
+The generic `$H3Datagram` is defined here as a CDDL extension point (a "type
+socket" or "type plug"). It can be extended to support additional HTTP/3
+datagram types. This document intentionally does not define any specific HTTP/3
+Datagram types.
 
 ~~~ cddl
 ; The H3Datagram is any key-value map (e.g., JSON object)

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -261,7 +261,7 @@ change that.
 
 Unidirectional streams in either direction begin with with a variable-length
 integer type. Where the type is not known, the stream_type value of "unknown"
-type can be used and the value captured in the stream_type_value field; a
+type can be used and the value captured in the stream_type_bytes field; a
 numerical value without variable-length integer encoding.
 
 The generic `$H3StreamType` is defined here as a CDDL "type socket" extension
@@ -274,7 +274,7 @@ H3StreamTypeSet = {
     stream_type: $H3StreamType
 
     ; only when stream_type === "unknown"
-    ? stream_type_value: uint64
+    ? stream_type_bytes: uint64
 
     ; only when stream_type === "push"
     ? associated_push_id: uint64
@@ -638,13 +638,13 @@ H3ReservedFrame = {
 
 ### H3UnknownFrame
 
-The frame_type_value field is the numerical value without variable-length
+The frame_type_bytes field is the numerical value without variable-length
 integer encoding.
 
 ~~~ cddl
 H3UnknownFrame = {
     frame_type: "unknown"
-    frame_type_value: uint64
+    frame_type_bytes: uint64
     ? raw: RawInfo
 }
 ~~~

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -191,24 +191,10 @@ The "owner" field reflects how Settings are exchanged on a connection. Sent
 settings have the value "local" and received settings have the value
 "received".
 
-As a reminder the CDDL unwrap operator (~) (see {{?RFC8610}}), copies the fields
-from the referenced type (H3Parameters) into the target type directly, extending the
-target with the unwrapped fields.
-
 ~~~ cddl
 H3ParametersSet = {
     ? owner: Owner
-    ~H3Parameters
 
-    ; qlog-specific
-    ; indicates whether this implementation waits for a SETTINGS
-    ; frame before processing requests
-    ? waits_for_settings: bool
-
-    * $$h3-parametersset-extension
-}
-
-H3Parameters = {
     ; RFC9114
     ? max_field_section_size: uint64
 
@@ -222,16 +208,19 @@ H3Parameters = {
     ; RFC9297 (SETTINGS_H3_DATAGRAM)
     ? h3_datagram: uint16
 
-    * $$h3-parameters-extension
+    ; qlog-specific
+    ; indicates whether this implementation waits for a SETTINGS
+    ; frame before processing requests
+    ? waits_for_settings: bool
+
+    * $$h3-parametersset-extension
 }
 ~~~
 {: #h3-parametersset-def title="H3ParametersSet definition"}
 
 The `parameters_set` event can contain any number of unspecified fields. This
 allows for representation of reserved settings (aka GREASE) or ad-hoc support
-for extension settings that do not have a related qlog schema definition. For
-extension settings that do have a qlog schema defintion, the
-$$h3-parameters-extension socket SHOULD be used.
+for extension settings that do not have a related qlog schema definition.
 
 ## parameters_restored {#h3-parametersrestored}
 
@@ -242,7 +231,18 @@ utilizing 0-RTT. It has Base importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
 H3ParametersRestored = {
-    ~H3Parameters
+    ; RFC9114
+    ? max_field_section_size: uint64
+
+    ; RFC9204
+    ? max_table_capacity: uint64
+    ? blocked_streams_count: uint64
+
+    ; RFC9220 (SETTINGS_ENABLE_CONNECT_PROTOCOL)
+    ? extended_connect: uint16
+
+    ; RFC9297 (SETTINGS_H3_DATAGRAM)
+    ? h3_datagram: uint16
 
     * $$h3-parametersrestored-extension
 }

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -552,6 +552,9 @@ H3CancelPushFrame = {
 
 ### H3SettingsFrame
 
+The `name_bytes` field supports logging the raw value of a setting identifier,
+to support logging unknown settings.
+
 ~~~ cddl
 H3SettingsFrame = {
     frame_type: "settings"
@@ -559,7 +562,8 @@ H3SettingsFrame = {
 }
 
 H3Setting = {
-    name: text
+    ? name: text
+    ? name_bytes: uint64
     value: uint64
 }
 ~~~

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -196,6 +196,8 @@ H3ParametersSet = {
     ; indicates whether this implementation waits for a SETTINGS
     ; frame before processing requests
     ? waits_for_settings: bool
+
+    * $$h3-parametersset-extension
 }
 
 H3Parameters = {
@@ -214,6 +216,8 @@ H3Parameters = {
 
     ; additional settings for grease and extensions
     * text => uint64
+
+    * $$h3-parameters-extension
 }
 ~~~
 {: #h3-parametersset-def title="H3ParametersSet definition"}
@@ -232,6 +236,8 @@ utilizing 0-RTT. It has Base importance level; see {{Section 9.2 of QLOG-MAIN}}.
 ~~~ cddl
 H3ParametersRestored = {
     ~H3Parameters
+
+    * $$h3-parametersrestored-extension
 }
 ~~~
 {: #h3-parametersrestored-def title="H3ParametersRestored definition"}
@@ -266,6 +272,8 @@ H3StreamTypeSet = {
 
     ; only when stream_type === "push"
     ? associated_push_id: uint64
+
+    * $$h3-streamtypeset-extension
 }
 
 H3StreamType =  "request" /
@@ -297,6 +305,8 @@ H3PriorityUpdated = {
 
     ? old: H3Priority
     new: H3Priority
+
+    * $$h3-priorityupdated-extension
 }
 ~~~
 {: #h3-priorityupdated-def title="H3PriorityUpdated definition"}
@@ -315,6 +325,8 @@ H3FrameCreated = {
     ? length: uint64
     frame: $H3Frame
     ? raw: RawInfo
+
+    * $$h3-framecreated-extension
 }
 ~~~
 {: #h3-framecreated-def title="H3FrameCreated definition"}
@@ -334,6 +346,8 @@ H3FrameParsed = {
     ? length: uint64
     frame: $H3Frame
     ? raw: RawInfo
+
+    * $$h3-frameparsed-extension
 }
 ~~~
 {: #h3-frameparsed-def title="H3FrameParsed definition"}
@@ -357,6 +371,8 @@ H3DatagramCreated = {
     quarter_stream_id: uint64
     ? datagram: $H3Datagram
     ? raw: RawInfo
+
+    * $$h3-datagramcreated-extension
 }
 ~~~
 {: #h3-datagramcreated-def title="H3DatagramCreated definition"}
@@ -375,6 +391,8 @@ H3DatagramParsed = {
     quarter_stream_id: uint64
     ? datagram: $H3Datagram
     ? raw: RawInfo
+
+    * $$h3-datagramparsed-extension
 }
 ~~~
 {: #h3-datagramparsed-def title="H3DatagramParsed definition"}
@@ -395,10 +413,12 @@ H3PushResolved = {
     ; to the push_id
     ? stream_id: uint64
     decision: H3PushDecision
+
+    * $$h3-pushresolved-extension
 }
 
 H3PushDecision = "claimed" /
-                   "abandoned"
+                 "abandoned"
 ~~~
 {: #h3-pushresolved-def title="H3PushResolved definition"}
 

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -104,7 +104,12 @@ re-usable definitions, which are grouped together on the bottom of this document
 for clarity.
 
 When any event from this document is included in a qlog trace, the
-"protocol_type" qlog array field MUST contain an entry with the value "HTTP3".
+"protocol_type" qlog array field MUST contain an entry with the value "HTTP3":
+
+~~~ cddl
+$ProtocolType /= "HTTP3"
+~~~
+{: #protocoltype-extension-h3 title="ProtocolType extension for HTTP/3"}
 
 ## Usage with QUIC
 
@@ -186,7 +191,7 @@ The "owner" field reflects how Settings are exchanged on a connection. Sent
 settings have the value "local" and received settings have the value
 "received".
 
-As a reminder the CDDL unwrap operator (~), see {{?RFC8610}}), copies the fields
+As a reminder the CDDL unwrap operator (~) (see {{?RFC8610}}), copies the fields
 from the referenced type (H3Parameters) into the target type directly, extending the
 target with the unwrapped fields.
 
@@ -227,7 +232,9 @@ H3Parameters = {
 
 The `parameters_set` event can contain any number of unspecified fields. This
 allows for representation of reserved settings (aka GREASE) or ad-hoc support
-for extension settings that do not have a related qlog schema definition.
+for extension settings that do not have a related qlog schema definition. For
+extension settings that do have a qlog schema defintion, the
+$$h3-parameters-extension socket SHOULD be used.
 
 ## parameters_restored {#h3-parametersrestored}
 
@@ -245,10 +252,6 @@ H3ParametersRestored = {
 ~~~
 {: #h3-parametersrestored-def title="H3ParametersRestored definition"}
 
-The `parameters_restored` event can contain any number of unspecified fields. This
-allows for representation of reserved settings (aka GREASE) or ad-hoc support
-for extension settings that do not have a related qlog schema definition.
-
 ## stream_type_set {#h3-streamtypeset}
 
 The `stream_type_set` event conveys when a HTTP/3 stream type becomes known; see
@@ -264,11 +267,14 @@ integer type. Where the type is not known, the stream_type value of "unknown"
 type can be used and the value captured in the stream_type_value field; a
 numerical value without variable-length integer encoding.
 
+The generic `$H3StreamType` is defined here as a CDDL "type socket" extension
+point. It can be extended to support additional HTTP/3 stream types.
+
 ~~~ cddl
 H3StreamTypeSet = {
     ? owner: Owner
     stream_id: uint64
-    stream_type: H3StreamType
+    stream_type: $H3StreamType
 
     ; only when stream_type === "unknown"
     ? stream_type_value: uint64
@@ -279,7 +285,7 @@ H3StreamTypeSet = {
     * $$h3-streamtypeset-extension
 }
 
-H3StreamType =  "request" /
+$H3StreamType /=  "request" /
                   "control" /
                   "push" /
                   "reserved" /
@@ -439,17 +445,16 @@ Owner = "local" /
 
 ## H3Frame
 
-The generic `$H3Frame` is defined here as a CDDL extension point (a "type
-socket" or "type plug"). It can be extended to support additional HTTP/3 frame
-types.
+The generic `$H3Frame` is defined here as a CDDL "type socket" extension point.
+It can be extended to support additional HTTP/3 frame types.
 
-~~~ cddl
+~~~~~~
 ; The H3Frame is any key-value map (e.g., JSON object)
 $H3Frame /= {
     * text => any
 }
-~~~
-{: #h3-frame-def title="H3Frame plug definition"}
+~~~~~~
+{: #h3-frame-def title="H3Frame type socket definition"}
 
 The HTTP/3 frame types defined in this document are as follows:
 
@@ -470,18 +475,18 @@ $H3Frame /= H3BaseFrames
 
 ## H3Datagram
 
-The generic `$H3Datagram` is defined here as a CDDL extension point (a "type
-socket" or "type plug"). It can be extended to support additional HTTP/3
-datagram types. This document intentionally does not define any specific HTTP/3
-Datagram types.
+The generic `$H3Datagram` is defined here as a CDDL "type socket" extension
+point. It can be extended to support additional HTTP/3 datagram types. This
+document intentionally does not define any specific qlog schemas for specific
+HTTP/3 Datagram types.
 
-~~~ cddl
+~~~~~~
 ; The H3Datagram is any key-value map (e.g., JSON object)
 $H3Datagram /= {
     * text => any
 }
-~~~
-{: #h3-datagram-def title="H3Datagram plug definition"}
+~~~~~~
+{: #h3-datagram-def title="H3Datagram type socket definition"}
 
 ### H3DataFrame
 
@@ -667,11 +672,11 @@ H3ApplicationError = "http_no_error" /
 ~~~
 {: #h3-applicationerror-def title="H3ApplicationError definition"}
 
-The H3ApplicationError defines the general $ApplicationError
-definition in the qlog QUIC definition, see {{QLOG-QUIC}}.
+The H3ApplicationError extends the general $ApplicationError
+definition in the qlog QUIC document, see {{QLOG-QUIC}}.
 
 ~~~ cddl
-; ensure HTTP errors are properly validate in QUIC events as well
+; ensure HTTP errors are properly validated in QUIC events as well
 ; e.g., QUIC's ConnectionClose Frame
 $ApplicationError /= H3ApplicationError
 ~~~

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -222,9 +222,6 @@ H3Parameters = {
     ; RFC9297 (SETTINGS_H3_DATAGRAM)
     ? h3_datagram: uint16
 
-    ; additional settings for grease and extensions
-    * text => uint64
-
     * $$h3-parameters-extension
 }
 ~~~

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1039,6 +1039,8 @@ wire. It has Core importance level; see {{importance}}.
 GenericError = {
     ? code: uint64
     ? message: text
+
+    * $$generic-error-extension
 }
 ~~~
 {: #generic-error-def title="GenericError definition"}
@@ -1052,6 +1054,8 @@ wire. It has Base importance level; see {{importance}}.
 GenericWarning = {
     ? code: uint64
     ? message: text
+
+    * $$generic-warning-extension
 }
 ~~~
 {: #generic-warning-def title="GenericWarning definition"}
@@ -1065,6 +1069,8 @@ has Extra importance level; see {{importance}}.
 ~~~ cddl
 GenericInfo = {
     message: text
+
+    * $$generic-info-extension
 }
 ~~~
 {: #generic-info-def title="GenericInfo definition"}
@@ -1078,6 +1084,8 @@ has Extra importance level; see {{importance}}.
 ~~~ cddl
 GenericDebug = {
     message: text
+
+    * $$generic-debug-extension
 }
 ~~~
 {: #generic-debug-def title="GenericDebug definition"}
@@ -1091,6 +1099,8 @@ has Extra importance level; see {{importance}}.
 ~~~ cddl
 GenericVerbose = {
     message: text
+
+    * $$generic-verbose-extension
 }
 ~~~
 {: #generic-verbose-def title="GenericVerbose definition"}
@@ -1119,6 +1129,8 @@ one trace (e.g., split by `group_id`). It has Extra importance level; see
 SimulationScenario = {
     ? name: text
     ? details: {* text => any }
+
+    * $$simulation-scenario-extension
 }
 ~~~
 {: #simulation-scenario-def title="SimulationScenario definition"}
@@ -1133,6 +1145,8 @@ triggered). It has Extra importance level; see {{importance}}.
 SimulationMarker = {
     ? type: text
     ? message: text
+
+    * $$simulation-marker-extension
 }
 ~~~
 {: #simulation-marker-def title="SimulationMarker definition"}

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -509,7 +509,7 @@ Event = {
     data: $ProtocolEventData
     ? path: PathID
     ? time_format: TimeFormat
-    ? protocol_type: ProtocolType
+    ? protocol_type: ProtocolTypeList
     ? group_id: GroupID
     ? system_info: SystemInformation
 
@@ -725,10 +725,12 @@ MyCategoryEvent2 /= {
     * $$mycategory-event2-extension
 }
 
-; the events are both merged with the existing $ProtocolEventData type enum
+; the events are both merged with the existing
+; $ProtocolEventData type enum
 $ProtocolEventData /= MyCategoryEvent1 / MyCategoryEvent2
 
-; the "data" field of a qlog event can now also be of type MyCategoryEvent1 and MyCategoryEvent2
+; the "data" field of a qlog event can now also be of type
+; MyCategoryEvent1 and MyCategoryEvent2
 ~~~~~~~~
 {: #protocoleventdata-def title="ProtocolEventData extension"}
 
@@ -757,13 +759,15 @@ TransportPacketSent = {
 ; Add the event to the global list of recognized qlog events
 $ProtocolEventData /= TransportPacketSent
 
-; Defined in a separate document that describes a theoretical QUIC protocol extension
+; Defined in a separate document that describes a
+; theoretical QUIC protocol extension
 $$transport-packetsent-extension //= (
   ? additional_field: bool
 )
 
 ; If both documents are utilized at the same time,
-; the following JSON serialization would pass an automated CDDL schema validation check:
+; the following JSON serialization would pass an automated
+; CDDL schema validation check:
 
 {
   "time": 123456,
@@ -821,7 +825,7 @@ associated info in a separate event. For example, QUIC has the "path_assigned"
 event to couple the PathID value to a specific path configuration, see
 {{QLOG-QUIC}}.
 
-## ProtocolType {#protocol-type-field}
+## ProtocolTypeList and ProtocolType {#protocol-type-field}
 
 An event's "protocol_type" array field indicates to which protocols (or protocol
 "stacks") this event belongs. This allows a single qlog file to aggregate traces
@@ -829,9 +833,11 @@ of different protocols (e.g., a web server offering both TCP+HTTP/2 and
 QUIC+HTTP/3 connections).
 
 ~~~ cddl
-ProtocolType = [+ text]
+ProtocolTypeList = [+ $ProtocolType]
+
+$ProtocolType /= "UNKNOWN"
 ~~~
-{: #protocol-type-def title="ProtocolType definition"}
+{: #protocol-type-def title="ProtocolTypeList and ProtocolType socket definition"}
 
 For example, QUIC and HTTP/3 events have the "QUIC" and "HTTP3" protocol_type
 entry values, see {{QLOG-QUIC}} and {{QLOG-H3}}.
@@ -1036,7 +1042,7 @@ CommonFields = {
     ? path: PathID
     ? time_format: TimeFormat
     ? reference_time: float64
-    ? protocol_type: ProtocolType
+    ? protocol_type: ProtocolTypeList
     ? group_id: GroupID
     * text => any
 }

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -661,7 +661,7 @@ In order to keep qlog fully extensible, two separate CDDL extension points
 Firstly, to allow existing data field definitions to be extended (for example by
 adding an additional field needed for a new protocol feature), a CDDL "group
 socket" is used. This takes the form of a subfield with a name of
-`$$CATEGORY-NAME-extension`. This field acts as a placeholder that can later be
+`* $$CATEGORY-NAME-extension`. This field acts as a placeholder that can later be
 replaced with newly defined fields by assigning them to the socket with the
 `//=` operator. Multiple extensions can be assigned to the same group socket. An
 example is shown in {{groupsocket-extension-example}}.
@@ -671,7 +671,7 @@ example is shown in {{groupsocket-extension-example}}.
 MyCategoryEventX = {
     field_a: uint8
 
-    $$mycategory-eventx-extension
+    * $$mycategory-eventx-extension
 }
 
 ; later extension of EventX in document B
@@ -714,7 +714,7 @@ MyCategoryEvent1 /= {
 
     ? trigger: text
 
-    $$mycategory-event1-extension
+    * $$mycategory-event1-extension
 }
 
 MyCategoryEvent2 /= {
@@ -722,7 +722,7 @@ MyCategoryEvent2 /= {
 
     ? trigger: text
 
-    $$mycategory-event2-extension
+    * $$mycategory-event2-extension
 }
 
 ; the events are both merged with the existing $ProtocolEventData type enum
@@ -734,10 +734,9 @@ $ProtocolEventData /= MyCategoryEvent1 / MyCategoryEvent2
 
 Documents defining new qlog events MUST properly extend `$ProtocolEventData`
 when defining data fields to enable automated validation of aggregated qlog
-schemas. Furthermore, they SHOULD properly add a `$$CATEGORY-NAME-extension`
+schemas. Furthermore, they SHOULD properly add a `* $$CATEGORY-NAME-extension`
 extension field to newly defined event data to allow the new events to be
 properly extended by other documents.
-
 
 A combined but purely illustrative example of the use of both extension points
 for a conceptual QUIC "packet_sent" event is shown in {{data-ex}}:
@@ -752,13 +751,13 @@ TransportPacketSent = {
                "retransmit_timeout" /
                "bandwidth_probe"
 
-    $$transport-packetsent-extension
+    * $$transport-packetsent-extension
 }
 
-; make sure the event is added to the global list of recognized qlog events
+; Add the event to the global list of recognized qlog events
 $ProtocolEventData /= TransportPacketSent
 
-; defined in a separate document that defines a theoretical QUIC protocol extension
+; Defined in a separate document that describes a theoretical QUIC protocol extension
 $$transport-packetsent-extension //= (
   ? additional_field: bool
 )
@@ -767,8 +766,9 @@ $$transport-packetsent-extension //= (
 ; the following JSON serialization would pass an automated CDDL schema validation check:
 
 {
+  "time": 123456,
   "category": "transport",
-  "name": "packetsent",
+  "name": "packet_sent",
   "data": {
       "packet_size": 1280,
       "header": {
@@ -1092,6 +1092,20 @@ calculation.
 
 There are some event types and data classes that are common across protocols,
 applications, and use cases. This section specifies such common definitions.
+
+~~~ cddl
+GenericEventData = GenericError /
+                GenericWarning /
+                GenericInfo /
+                GenericDebug
+
+SimulationEventData = SimulationScenario /
+                SimulationMarker
+
+$ProtocolEventData /= GenericEventData / SimulationEventData
+~~~
+{: #commonevent-integration title="ProtocolEventData extension for common
+events"}
 
 ## Generic events
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1186,23 +1186,19 @@ QUICStreamDataMoved = {
 
     ; byte length of the moved data
     ? length: uint64
-    ? from: "user" /
-            "application" /
-            "transport" /
-            "network" /
-            text
-    ? to: "user" /
-          "application" /
-          "transport" /
-          "network" /
-          text
+    ? from: $DataLocation
+    ? to: $DataLocation
     ? raw: RawInfo
 
     * $$quic-streamdatamoved-extension
 }
+
+$DataLocation /=  "user" /
+                  "application" /
+                  "transport" /
+                  "network"
 ~~~
 {: #quic-streamdatamoved-def title="QUICStreamDataMoved definition"}
-
 
 ## datagram_data_moved {#quic-datagramdatamoved}
 
@@ -1230,24 +1226,14 @@ see the `stream_data_moved` event defined in {{quic-streamdatamoved}}.
 QUICDatagramDataMoved = {
     ; byte length of the moved data
     ? length: uint64
-    ? from: "user" /
-            "application" /
-            "transport" /
-            "network" /
-            text
-    ? to: "user" /
-          "application" /
-          "transport" /
-          "network" /
-          text
+    ? from: $DataLocation
+    ? to: $DataLocation
     ? raw: RawInfo
 
     * $$quic-datagramdatamoved-extension
 }
 ~~~
 {: #quic-datagramdatamoved-def title="QUICDatagramDataMoved definition"}
-
-
 
 ## migration_state_updated {#quic-migrationstateupdated}
 Importance: Extra

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1827,7 +1827,7 @@ $QuicFrame /= {
 The QUIC frame types defined in this document are as follows:
 
 ~~~ cddl
-QuicBaseFrames /= PaddingFrame /
+QuicBaseFrames =  PaddingFrame /
                   PingFrame /
                   AckFrame /
                   ResetStreamFrame /

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1050,21 +1050,22 @@ QUICStreamStateUpdated = {
 
     ; mainly useful when opening the stream
     ? stream_type: StreamType
-    ? old: StreamState
-    new: StreamState
+    ? old: $StreamState
+    new: $StreamState
     ? stream_side: "sending" /
                    "receiving"
 
     * $$quic-streamstateupdated-extension
 }
 
-StreamState =
+BaseStreamStates =  "idle" /
+                    "open" /
+                    "closed"
+
+GranularStreamStates =
     ; bidirectional stream states, RFC 9000 Section 3.4.
-    "idle" /
-    "open" /
     "half_closed_local" /
     "half_closed_remote" /
-    "closed" /
     ; sending-side stream states, RFC 9000 Section 3.1.
     "ready" /
     "send" /
@@ -1078,17 +1079,17 @@ StreamState =
     "reset_read" /
     ; both-side states
     "data_received" /
-    ; qlog-defined:
-    ; memory actually freed
+    ; qlog-defined: memory actually freed
     "destroyed"
+
+$StreamState /= BaseStreamStates / GranularStreamStates
 ~~~
 {: #quic-streamstateupdated-def title="QUICStreamStateUpdated definition"}
 
-QUIC implementations SHOULD mainly log the simplified bidirectional
-(HTTP/2-alike) stream states (e.g., `idle`, `open`, `closed`) instead of the more
-fine-grained stream states (e.g., `data_sent`, `reset_received`). These latter ones are
-mainly for more in-depth debugging. Tools SHOULD be able to deal with both types
-equally.
+QUIC implementations SHOULD mainly log the simplified (HTTP/2-alike)
+BaseStreamStates instead of the more fine-grained GranularStreamStates. These
+latter ones are mainly for more in-depth debugging. Tools SHOULD be able to deal
+with both types equally.
 
 ## frames_processed {#quic-framesprocessed}
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -99,7 +99,12 @@ re-usable definitions, which are grouped together on the bottom of this document
 for clarity.
 
 When any event from this document is included in a qlog trace, the
-`protocol_type` qlog array field MUST contain an entry with the value "QUIC".
+`protocol_type` qlog array field MUST contain an entry with the value "QUIC":
+
+~~~ cddl
+$ProtocolType /= "QUIC"
+~~~
+{: #protocoltype-extension-quic title="ProtocolType extension for QUIC"}
 
 When the qlog `group_id` field is used, it is recommended to use QUIC's Original
 Destination Connection ID (ODCID, the CID chosen by the client when first
@@ -329,7 +334,7 @@ ConnectivityConnectionClosed = {
 
     ; which side closed the connection
     ? owner: Owner
-    ? connection_code: TransportError /
+    ? connection_code: $TransportError /
                        CryptoError /
                        uint32
     ? application_code: $ApplicationError /
@@ -1808,17 +1813,16 @@ The ECN bits carried in the IP header.
 
 ## QUIC Frames
 
-The generic `$QuicFrame` is defined here as a CDDL extension point (a "type
-socket" or "type plug"). It can be extended to support additional QUIC frame
-types.
+The generic `$QuicFrame` is defined here as a CDDL "type socket" extension
+point. It can be extended to support additional QUIC frame types.
 
-~~~ cddl
+~~~~~~
 ; The QuicFrame is any key-value map (e.g., JSON object)
 $QuicFrame /= {
     * text => any
 }
-~~~
-{: #quicframe-def title="QuicFrame plug definition"}
+~~~~~~
+{: #quicframe-def title="QuicFrame type socket definition"}
 
 The QUIC frame types defined in this document are as follows:
 
@@ -2134,7 +2138,7 @@ ErrorSpace = "transport" /
 ConnectionCloseFrame = {
     frame_type: "connection_close"
     ? error_space: ErrorSpace
-    ? error_code: TransportError /
+    ? error_code: $TransportError /
                   CryptoError /
                   $ApplicationError /
                   uint64
@@ -2184,8 +2188,11 @@ DatagramFrame = {
 
 ### TransportError
 
+The generic `$TransportError` is defined here as a CDDL "type socket" extension
+point. It can be extended to support additional Transport errors.
+
 ~~~ cddl
-TransportError = "no_error" /
+$TransportError /= "no_error" /
                  "internal_error" /
                  "connection_refused" /
                  "flow_control_error" /
@@ -2212,16 +2219,16 @@ TransportError = "no_error" /
 By definition, an application error is defined by the application-level
 protocol running on top of QUIC (e.g., HTTP/3).
 
-As such, it cannot be defined here directly. Applications MAY use the provided
-extension point through the use of the CDDL "type socket" mechanism.
+As such, it cannot be defined here directly. It is instead defined as an empty
+CDDL "type socket" extension point.
 
 Application-level qlog definitions that wish to define new ApplicationError
 strings MUST do so by extending the $ApplicationError socket as such:
 
-~~~
+~~~~~~
 $ApplicationError /= "new_error_name" /
                      "another_new_error_name"
-~~~
+~~~~~~
 
 ### CryptoError
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -933,7 +933,7 @@ implementations that do not log frame contents.
 
 ~~~ cddl
 QUICPacketsAcked = {
-    ? packet_number_space: PacketNumberSpace
+    ? packet_number_space: $PacketNumberSpace
     ? packet_numbers: [+ uint64]
 
     * $$quic-packetsacked-extension
@@ -1517,7 +1517,7 @@ RecoveryLossTimerUpdated = {
     ; called "mode" in RFC 9002 A.9.
     ? timer_type: "ack" /
                   "pto"
-    ? packet_number_space: PacketNumberSpace
+    ? packet_number_space: $PacketNumberSpace
     event_type: "set" /
                 "expired" /
                 "cancelled"
@@ -1696,7 +1696,7 @@ PathEndpointInfo = {
 ## PacketType
 
 ~~~ cddl
-PacketType = "initial" /
+BasePacketTypes = "initial" /
              "handshake" /
              "0RTT" /
              "1RTT" /
@@ -1704,15 +1704,19 @@ PacketType = "initial" /
              "version_negotiation" /
              "stateless_reset" /
              "unknown"
+
+$PacketType /= BasePacketTypes
 ~~~
 {: #packettype-def title="PacketType definition"}
 
 ## PacketNumberSpace
 
 ~~~ cddl
-PacketNumberSpace = "initial" /
-                    "handshake" /
-                    "application_data"
+BasePacketNumberSpaces =  "initial" /
+                          "handshake" /
+                          "application_data"
+
+$PacketNumberSpace /= BasePacketNumberSpaces
 ~~~
 {: #packetnumberspace-def title="PacketNumberSpace definition"}
 
@@ -1721,7 +1725,7 @@ PacketNumberSpace = "initial" /
 ~~~ cddl
 PacketHeader = {
     ? quic_bit: bool .default true
-    packet_type: PacketType
+    packet_type: $PacketType
 
     ; only if packet_type === "initial" || "handshake" || "0RTT" ||
     ;                         "1RTT"

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1683,27 +1683,23 @@ PathEndpointInfo = {
 ## PacketType
 
 ~~~ cddl
-BasePacketTypes = "initial" /
-             "handshake" /
-             "0RTT" /
-             "1RTT" /
-             "retry" /
-             "version_negotiation" /
-             "stateless_reset" /
-             "unknown"
-
-$PacketType /= BasePacketTypes
+$PacketType /=  "initial" /
+                "handshake" /
+                "0RTT" /
+                "1RTT" /
+                "retry" /
+                "version_negotiation" /
+                "stateless_reset" /
+                "unknown"
 ~~~
 {: #packettype-def title="PacketType definition"}
 
 ## PacketNumberSpace
 
 ~~~ cddl
-BasePacketNumberSpaces =  "initial" /
-                          "handshake" /
-                          "application_data"
-
-$PacketNumberSpace /= BasePacketNumberSpaces
+$PacketNumberSpace /= "initial" /
+                      "handshake" /
+                      "application_data"
 ~~~
 {: #packetnumberspace-def title="PacketNumberSpace definition"}
 
@@ -1760,10 +1756,8 @@ Token = {
     * $$quic-token-extension
 }
 
-BaseTokenType = "retry" /
-                "resumption"
-
-$TokenType /= BaseTokenType
+$TokenType /= "retry" /
+              "resumption"
 ~~~
 {: #token-def title="Token definition"}
 
@@ -1787,16 +1781,14 @@ parameters and in NEW_CONNECTION_ID frames.
 ## KeyType
 
 ~~~ cddl
-BaseKeyTypes =  "server_initial_secret" /
-                "client_initial_secret" /
-                "server_handshake_secret" /
-                "client_handshake_secret" /
-                "server_0rtt_secret" /
-                "client_0rtt_secret" /
-                "server_1rtt_secret" /
-                "client_1rtt_secret"
-
-$KeyType /= BaseKeyTypes
+$KeyType /= "server_initial_secret" /
+            "client_initial_secret" /
+            "server_handshake_secret" /
+            "client_handshake_secret" /
+            "server_0rtt_secret" /
+            "client_0rtt_secret" /
+            "server_1rtt_secret" /
+            "client_1rtt_secret"
 ~~~
 {: #keytype-def title="KeyType definition"}
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2151,7 +2151,8 @@ HandshakeDoneFrame = {
 
 ### UnknownFrame
 
-The frame_type_bytes field is the numerical value without VLIE encoding.
+The frame_type_bytes field is the numerical value without variable-length
+integer encoding.
 
 ~~~ cddl
 UnknownFrame = {

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -265,6 +265,8 @@ ConnectivityServerListening = {
     ; the server will always answer client initials with a retry
     ; (no 1-RTT connection setups by choice)
     ? retry_required: bool
+
+    * $$connectivity-serverlistening-extension
 }
 ~~~
 {: #connectivity-serverlistening-def title="ConnectivityServerListening definition"}
@@ -292,6 +294,8 @@ ConnectivityConnectionStarted = {
     ? dst_port: uint16
     ? src_cid: ConnectionID
     ? dst_cid: ConnectionID
+
+    * $$connectivity-connectionstarted-extension
 }
 ~~~
 {: #connectivity-connectionstarted-def title="ConnectivityConnectionStarted definition"}
@@ -340,6 +344,8 @@ ConnectivityConnectionClosed = {
         "version_mismatch" /
         ; for example HTTP/3's GOAWAY frame
         "application"
+
+    * $$connectivity-connectionclosed-extension
 }
 ~~~
 {: #connectivity-connectionclosed-def title="ConnectivityConnectionClosed definition"}
@@ -363,6 +369,8 @@ ConnectivityConnectionIDUpdated = {
     owner: Owner
     ? old: ConnectionID
     ? new: ConnectionID
+
+    * $$connectivity-connectionidupdated-extension
 }
 ~~~
 {: #connectivity-connectionidupdated-def title="ConnectivityConnectionIDUpdated definition"}
@@ -378,6 +386,8 @@ QLOG-MAIN}}.
 ~~~ cddl
 ConnectivitySpinBitUpdated = {
     state: bool
+
+    * $$connectivity-spinbitupdated-extension
 }
 ~~~
 {: #connectivity-spinbitupdated-def title="ConnectivitySpinBitUpdated definition"}
@@ -400,6 +410,8 @@ ConnectivityConnectionStateUpdated = {
            SimpleConnectionState
     new: ConnectionState /
          SimpleConnectionState
+
+    * $$connectivity-connectionstateupdated-extension
 }
 
 ConnectionState =
@@ -499,6 +511,8 @@ ConnectivityPathAssigned = {
 
     ; the information for traffic coming in at the local endpoint
     ? path_local: PathEndpointInfo
+
+    * $$connectivity-pathassigned-extension
 }
 ~~~
 {: #connectivity-pathassigned-def title="ConnectivityPathAssigned definition"}
@@ -532,12 +546,14 @@ level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
 ConnectivityMTUUpdated = {
-  ? old: uint32
-  new: uint32
+    ? old: uint32
+    new: uint32
 
-  ; at some point, MTU discovery stops, as a "good enough"
-  ; packet size has been found
-  ? done: bool .default false
+    ; at some point, MTU discovery stops, as a "good enough"
+    ; packet size has been found
+    ? done: bool .default false
+
+    * $$connectivity-mtuupdated-extension
 }
 ~~~
 {: #connectivity-mtuupdated-def title="ConnectivityMTUUpdated definition"}
@@ -563,6 +579,8 @@ QUICVersionInformation = {
     ? server_versions: [+ QuicVersion]
     ? client_versions: [+ QuicVersion]
     ? chosen_version: QuicVersion
+
+    * $$quic-versioninformation-extension
 }
 ~~~
 {: #quic-versioninformation-def title="QUICVersionInformation definition"}
@@ -602,6 +620,8 @@ QUICALPNInformation = {
     ? server_alpns: [* ALPNIdentifier]
     ? client_alpns: [* ALPNIdentifier]
     ? chosen_alpn: ALPNIdentifier
+
+    * $$quic-alpninformation-extension
 }
 
 ALPNIdentifier = {
@@ -778,6 +798,8 @@ QUICPacketSent = {
       ; needed for some CCs to figure out bandwidth allocations
       ; when there are no normal sends
       "cc_bandwidth_probe"
+
+    * $$quic-packetsent-extension
 }
 ~~~
 {: #quic-packetsent-def title="QUICPacketSent definition"}
@@ -813,6 +835,8 @@ QUICPacketReceived = {
         ; if packet was buffered because it couldn't be
         ; decrypted before
         "keys_available"
+
+    * $$quic-packetreceived-extension
 }
 ~~~
 {: #quic-packetreceived-def title="QUICPacketReceived definition"}
@@ -852,6 +876,8 @@ QUICPacketDropped = {
         "decryption_failure" /
         "key_unavailable" /
         "general"
+
+    * $$quic-packetdropped-extension
 }
 ~~~
 {: #quic-packetdropped-def title="QUICPacketDropped definition"}
@@ -893,6 +919,8 @@ QUICPacketBuffered = {
         ; if packet cannot be decrypted because the proper keys were
         ; not yet available
         "keys_unavailable"
+
+    * $$quic-packetbuffered-extension
 }
 ~~~
 {: #quic-packetbuffered-def title="QUICPacketBuffered definition"}
@@ -916,6 +944,8 @@ implementations that do not log frame contents.
 QUICPacketsAcked = {
     ? packet_number_space: PacketNumberSpace
     ? packet_numbers: [+ uint64]
+
+    * $$quic-packetsacked-extension
 }
 ~~~
 {: #quic-packetsacked-def title="QUICPacketsAcked definition"}
@@ -946,6 +976,8 @@ QUICUDPDatagramsSent = {
     ? ecn: [+ ECN]
 
     ? datagram_ids: [+ uint32]
+
+    * $$quic-udpdatagramssent-extension
 }
 ~~~
 {: #quic-udpdatagramssent-def title="QUICUDPDatagramsSent definition"}
@@ -982,6 +1014,8 @@ QUICUDPDatagramsReceived = {
     ? ecn: [+ ECN]
 
     ? datagram_ids: [+ uint32]
+
+    * $$quic-udpdatagramsreceived-extension
 }
 ~~~
 {: #quic-udpdatagramsreceived-def title="QUICUDPDatagramsReceived definition"}
@@ -1002,6 +1036,8 @@ QUICUDPDatagramDropped = {
     ; The RawInfo fields do not include the UDP headers,
     ; only the UDP payload
     ? raw: RawInfo
+
+    * $$quic-udpdatagramdropped-extension
 }
 ~~~
 {: #quic-udpdatagramdropped-def title="QUICUDPDatagramDropped definition"}
@@ -1027,6 +1063,8 @@ QUICStreamStateUpdated = {
     new: StreamState
     ? stream_side: "sending" /
                    "receiving"
+
+    * $$quic-streamstateupdated-extension
 }
 
 StreamState =
@@ -1103,6 +1141,8 @@ corresponding packet number at the same index.
 QUICFramesProcessed = {
     frames: [* $QuicFrame]
     ? packet_numbers: [* uint64]
+
+    * $$quic-framesprocessed-extension
 }
 ~~~
 {: #quic-framesprocessed-def title="QUICFramesProcessed definition"}
@@ -1165,6 +1205,8 @@ QUICStreamDataMoved = {
           "network" /
           text
     ? raw: RawInfo
+
+    * $$quic-streamdatamoved-extension
 }
 ~~~
 {: #quic-streamdatamoved-def title="QUICStreamDataMoved definition"}
@@ -1207,6 +1249,8 @@ QUICDatagramDataMoved = {
           "network" /
           text
     ? raw: RawInfo
+
+    * $$quic-datagramdatamoved-extension
 }
 ~~~
 {: #quic-datagramdatamoved-def title="QUICDatagramDataMoved definition"}
@@ -1245,6 +1289,8 @@ QUICMigrationStateUpdated = {
 
     ; the information for traffic coming in at the local endpoint
     ? path_local: PathEndpointInfo
+
+    * $$quic-migrationstateupdated-extension
 }
 
 ; Note that MigrationState does not describe a full state machine
@@ -1288,6 +1334,8 @@ SecurityKeyUpdated = {
         "tls" /
         "remote_update" /
         "local_update"
+
+    * $$quic-keyupdated-extension
 }
 ~~~
 {: #security-keyupdated-def title="SecurityKeyUpdated definition"}
@@ -1314,6 +1362,8 @@ SecurityKeyDiscarded = {
         "tls" /
         "remote_update" /
         "local_update"
+
+    * $$quic-keydiscarded-extension
 }
 ~~~
 {: #security-keydiscarded-def title="SecurityKeyDiscarded definition"}
@@ -1365,6 +1415,8 @@ RecoveryParametersSet = {
 
     ; as PTO multiplier
     ? persistent_congestion_threshold: uint16
+
+    * $$recovery-parametersset-extension
 }
 ~~~
 {: #recovery-parametersset-def title="RecoveryParametersSet definition"}
@@ -1409,6 +1461,8 @@ RecoveryMetricsUpdated = {
 
     ; in bits per second
     ? pacing_rate: uint64
+
+    * $$recovery-metricsupdated-extension
 }
 ~~~
 {: #recovery-metricsupdated-def title="RecoveryMetricsUpdated definition"}
@@ -1441,6 +1495,8 @@ RecoveryCongestionStateUpdated = {
     ? old: text
     new: text
     ? trigger: text
+
+    * $$recovery-congestionstateupdated-extension
 }
 ~~~
 {: #recovery-congestionstateupdated-def title="RecoveryCongestionStateUpdated definition"}
@@ -1478,6 +1534,8 @@ RecoveryLossTimerUpdated = {
     ; if event_type === "set": delta time is in ms from
     ; this event's timestamp until when the timer will trigger
     ? delta: float32
+
+    * $$recovery-losstimerupdated-extension
 }
 ~~~
 {: #recovery-losstimerupdated-def title="RecoveryLossTimerUpdated definition"}
@@ -1505,6 +1563,8 @@ RecoveryPacketLost = {
         "time_threshold" /
         ; RFC 9002 Section 6.2.4 paragraph 6, MAY
         "pto_expired"
+
+    * $$recovery-packetlost-extension
 }
 ~~~
 {: #recovery-packetlost-def title="RecoveryPacketLost definition"}
@@ -1535,6 +1595,8 @@ when data was retransmitted).
 ~~~ cddl
 RecoveryMarkedForRetransmit = {
     frames: [+ $QuicFrame]
+
+    * $$recovery-markedforretransmit-extension
 }
 ~~~
 {: #recovery-markedforretransmit-def title="RecoveryMarkedForRetransmit definition"}
@@ -1549,6 +1611,8 @@ level; see {{Section 9.2 of QLOG-MAIN}}.
 ECNStateUpdated = {
    ? old: ECNState
     new: ECNState
+
+    * $$recovery-ecnstateupdated-extension
 }
 
 ECNState =
@@ -1632,6 +1696,8 @@ PathEndpointInfo = {
     ; there are situations where there can be an overlap
     ; or a need to keep track of previous ConnectionIDs
     ? connection_ids: [+ ConnectionID]
+
+    * $$quic-pathendpointinfo-extension
 }
 ~~~
 {: #pathendpointinfo-def title="PathEndpointInfo definition"}
@@ -1690,6 +1756,8 @@ PacketHeader = {
     ? dcil: uint8
     ? scid: ConnectionID
     ? dcid: ConnectionID
+
+    * $$quic-packetheader-extension
 }
 ~~~
 {: #packetheader-def title="PacketHeader definition"}
@@ -1707,6 +1775,8 @@ Token = {
       * text => any
     }
     ? raw: RawInfo
+
+    * $$quic-token-extension
 }
 ~~~
 {: #token-def title="Token definition"}

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2151,12 +2151,12 @@ HandshakeDoneFrame = {
 
 ### UnknownFrame
 
-The frame_type_value field is the numerical value without VLIE encoding.
+The frame_type_bytes field is the numerical value without VLIE encoding.
 
 ~~~ cddl
 UnknownFrame = {
     frame_type: "unknown"
-    frame_type_value: uint64
+    frame_type_bytes: uint64
     ? raw: RawInfo
 }
 ~~~

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -208,7 +208,9 @@ this specification.
 {: #quic-events title="QUIC Events"}
 
 QUIC events extend the `$ProtocolEventData` extension point defined in
-{{QLOG-MAIN}}.
+{{QLOG-MAIN}}. Additionally, they allow for direct extensibility by their use of
+per-event extension points via the `$$` CDDL "group socket" syntax, as also
+described in {{QLOG-MAIN}}.
 
 ~~~ cddl
 QuicEventData = ConnectivityServerListening /
@@ -719,18 +721,6 @@ PreferredAddress = {
 ~~~
 {: #quic-parametersset-def title="QUICParametersSet definition"}
 
-The generic `$$quic-parametersset-extension` is defined here as a CDDL extension
-point (a "group socket"). It can be used to support additional, unknown, custom,
-and greased parameters. An example of such an extension can be found in
-{{parametersset-extension-example}}.
-
-~~~~~~~~
-$$quic-parametersset-extension //= (
-  ? new_transport_parameter: uint64
-)
-~~~~~~~~
-{: #parametersset-extension-example title="quic-parametersset-extension example"}
-
 ## parameters_restored {#quic-parametersrestored}
 
 When using QUIC 0-RTT, clients are expected to remember and restore the server's
@@ -760,10 +750,6 @@ QUICParametersRestored = {
 }
 ~~~
 {: #quic-parametersrestored-def title="QUICParametersRestored definition"}
-
-The generic `$$quic-parametersrestored-extension` is defined here as a CDDL
-extension point (a "group socket"). It can be used to support additional and
-custom parameters.
 
 ## packet_sent {#quic-packetsent}
 
@@ -1822,8 +1808,9 @@ The ECN bits carried in the IP header.
 
 ## QUIC Frames
 
-The generic `$QuicFrame` is defined here as a CDDL extension point (a "socket"
-or "plug"). It can be extended to support additional QUIC frame types.
+The generic `$QuicFrame` is defined here as a CDDL extension point (a "type
+socket" or "type plug"). It can be extended to support additional QUIC frame
+types.
 
 ~~~ cddl
 ; The QuicFrame is any key-value map (e.g., JSON object)
@@ -2226,9 +2213,10 @@ By definition, an application error is defined by the application-level
 protocol running on top of QUIC (e.g., HTTP/3).
 
 As such, it cannot be defined here directly. Applications MAY use the provided
-extension point through the use of the CDDL "socket" mechanism.
+extension point through the use of the CDDL "type socket" mechanism.
 
-Application-level qlog definitions that wish to define new ApplicationError strings MUST do so by extending the $ApplicationError socket as such:
+Application-level qlog definitions that wish to define new ApplicationError
+strings MUST do so by extending the $ApplicationError socket as such:
 
 ~~~
 $ApplicationError /= "new_error_name" /

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1300,7 +1300,7 @@ The `key_updated` event has Base importance level; see {{Section 9.2 of QLOG-MAI
 
 ~~~ cddl
 SecurityKeyUpdated = {
-    key_type: KeyType
+    key_type: $KeyType
     ? old: hexstring
     ? new: hexstring
 
@@ -1329,7 +1329,7 @@ QLOG-MAIN}}.
 
 ~~~ cddl
 SecurityKeyDiscarded = {
-    key_type: KeyType
+    key_type: $KeyType
     ? key: hexstring
 
     ; needed for 1RTT key updates
@@ -1748,8 +1748,7 @@ PacketHeader = {
 
 ~~~ cddl
 Token = {
-    ? type: "retry" /
-            "resumption"
+    ? type: $TokenType
 
     ; decoded fields included in the token
     ; (typically: peer's IP address, creation time)
@@ -1760,6 +1759,11 @@ Token = {
 
     * $$quic-token-extension
 }
+
+BaseTokenType = "retry" /
+                "resumption"
+
+$TokenType /= BaseTokenType
 ~~~
 {: #token-def title="Token definition"}
 
@@ -1783,14 +1787,16 @@ parameters and in NEW_CONNECTION_ID frames.
 ## KeyType
 
 ~~~ cddl
-KeyType = "server_initial_secret" /
-          "client_initial_secret" /
-          "server_handshake_secret" /
-          "client_handshake_secret" /
-          "server_0rtt_secret" /
-          "client_0rtt_secret" /
-          "server_1rtt_secret" /
-          "client_1rtt_secret"
+BaseKeyTypes =  "server_initial_secret" /
+                "client_initial_secret" /
+                "server_handshake_secret" /
+                "client_handshake_secret" /
+                "server_0rtt_secret" /
+                "client_0rtt_secret" /
+                "server_1rtt_secret" /
+                "client_1rtt_secret"
+
+$KeyType /= BaseKeyTypes
 ~~~
 {: #keytype-def title="KeyType definition"}
 


### PR DESCRIPTION
Fixes #379.
Also closes https://github.com/quicwg/qlog/issues/261, https://github.com/quicwg/qlog/issues/176, https://github.com/quicwg/qlog/issues/170, https://github.com/quicwg/qlog/issues/124, https://github.com/quicwg/qlog/issues/192, https://github.com/quicwg/qlog/issues/297.

Adds extensibility for all events through the `* $$category-name-ext` pattern first used in #400, now extended to ALL events as discussed in #379.

Makes all official protocol extension points also extensible in qlog. This was mostly already the case except for a few holdouts ($H3StreamType, $ProtocolType, $TransportError). The full list currently is:
- frames: $QuicFrame and $H3Frame and $H3Datagram
- TPs: $$quic-parametersset-extension and $$quic-parametersrestored-extension 
- settings: $$h3-parameters-extension (and inherently H3Setting by the way it's defined)
- H3 stream types: $H3StreamType
- error codes: $ApplicationError, $TransportError
- ALPN (at least qlog-level APLN; the other one is inherent in ALPNInformation): $ProtocolType

I don't think we need to make QUIC's StreamType extensible (since that's also in the RFC as always just uni- or bidirectional, with no way to change that through IANA (or even wire image, due to looking at the 2 LSBs)). Thoughts on this @LPardue ?


