### PR TITLE
Clarify no-ordering expectation for qlog fields

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -157,12 +157,12 @@ logged as `float64` in the millisecond resolution.
 Other qlog documents can define their own CDDL-compatible (struct) types
 (e.g., separately for each Packet type that a protocol supports).
 
-The member fields in all qlog CDDL type definitions are listed without any
-expectation of a fixed ordering. Specific qlog serializations MAY impose a
-stricter ordering of fields, but the default JSON and JSON Text Sequences
-serializations discussed in this document (see {{concrete-formats}}) do not.
-qlog tools SHOULD NOT assume a specific ordering of qlog member field
-occurrences in general.
+The ordering of member fields in qlog CDDL type definitions is not significant.
+The ordering of member field in the serialization formats defined in this
+document, JSON ({{format-json}}) and JSON Text Sequences ({{format-json-seq}}),
+is not significant and qlog tools MUST NOT assume so. Other qlog serialization
+formats MAY define field order significance, if they do they MUST define
+requirements for qlog tools supporting those formats.
 
 > Note to RFC editor: Please remove the following text in this section before
 publication.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -157,6 +157,13 @@ logged as `float64` in the millisecond resolution.
 Other qlog documents can define their own CDDL-compatible (struct) types
 (e.g., separately for each Packet type that a protocol supports).
 
+The member fields in all qlog CDDL type definitions are listed without any
+expectation of a fixed ordering. Specific qlog serializations MAY impose a
+stricter ordering of fields, but the default JSON and JSON Text Sequences
+serializations discussed in this document (see {{concrete-formats}}) do not.
+qlog tools SHOULD NOT assume a specific ordering of qlog member field
+occurrences in general.
+
 > Note to RFC editor: Please remove the following text in this section before
 publication.
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -158,7 +158,7 @@ Other qlog documents can define their own CDDL-compatible (struct) types
 (e.g., separately for each Packet type that a protocol supports).
 
 The ordering of member fields in qlog CDDL type definitions is not significant.
-The ordering of member field in the serialization formats defined in this
+The ordering of member fields in the serialization formats defined in this
 document, JSON ({{format-json}}) and JSON Text Sequences ({{format-json-seq}}),
 is not significant and qlog tools MUST NOT assume so. Other qlog serialization
 formats MAY define field order significance, if they do they MUST define


### PR DESCRIPTION
As noticed by @LPardue [here](https://github.com/quicwg/qlog/pull/417#discussion_r1529706045), we don't actually say anywhere that CDDL field ordering does not matter (it's implied by CDDL and JSON themselves, but probably good to reinforce explicitly).

 Not the biggest fan of current prose... tried to find examples in other RFCs but they're all over the place :) So let me know if you'd like to see it worded differently. 

