### PR TITLE
Make intent of triggers for connection_closed clearer

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -347,7 +347,7 @@ ConnectivityConnectionClosed = {
 ~~~
 {: #connectivity-connectionclosed-def title="ConnectivityConnectionClosed definition"}
 
-Loggers should use the most descriptive trigger for a `connection_closed` event
+Loggers SHOULD use the most descriptive trigger for a `connection_closed` event
 that they are able to deduce. This is often clear at the peer closing the
 connection (and sending the CONNECTION_CLOSE), but can sometimes be more opaque
 at the receiving end.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -330,7 +330,6 @@ ConnectivityConnectionClosed = {
         "error" /
         "stateless_reset" /
         "version_mismatch" /
-        ; for example HTTP/3's GOAWAY frame
         "application"
 
     * $$connectivity-connectionclosed-extension

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -304,6 +304,16 @@ deployments, it can be useful to have a single event representing a
 provide more information. Furthermore, it is useful to log closures due to
 timeouts, which are difficult to reflect using the other options.
 
+The `connection_closed` event is intended to be logged either when the local
+endpoint silently discards the connection due to an idle timeout, when a
+CONNECTION_CLOSE frame is sent (the connection enters the 'closing' state on the
+sender side), when a CONNECTION_CLOSE frame is received (the connection enters
+the 'draining' state on the receiver side) or when a Stateless Reset packet is
+received (the connection is discarded at the receiver side).
+Connectivity-related updates after this point (e.g., exiting a 'closing' or
+'draining' state), should be logged using the `connection_state_updated` event
+instead.
+
 In QUIC there are two main connection-closing error categories: connection and
 application errors. They have well-defined error codes and semantics. Next to
 these however, there can be internal errors that occur that may or may not get
@@ -323,19 +333,24 @@ ConnectivityConnectionClosed = {
     ? internal_code: uint32
     ? reason: text
     ? trigger:
-        "clean" /
-        "handshake_timeout" /
         "idle_timeout" /
-        ; this is called the "immediate close" in the QUIC RFC
+        "application" /
         "error" /
-        "stateless_reset" /
         "version_mismatch" /
-        "application"
+        ; when received from peer
+        "stateless_reset" /
+        ; when it is unclear what triggered the CONNECTION_CLOSE
+        "unspecified"
 
     * $$connectivity-connectionclosed-extension
 }
 ~~~
 {: #connectivity-connectionclosed-def title="ConnectivityConnectionClosed definition"}
+
+Loggers should use the most descriptive trigger for a `connection_closed` event
+that they are able to deduce. This is often clear at the peer closing the
+connection (and sending the CONNECTION_CLOSE), but can sometimes be more opaque
+at the receiving end.
 
 
 ## connection_id_updated {#connectivity-connectionidupdated}


### PR DESCRIPTION
Closes #410 

@LPardue PTAL. I still think having an `application` value here is useful (e.g., user force-closed the connection somehow, or application decided to abandon it without waiting for clean shutoff without additional info). But as discussed on #410 the GOAWAY example was probably incorrect. 