### PR TITLE
Behold - schema

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -80,8 +80,10 @@ The schema namespace `http` is defined, containing the category `h3`; see
 Event class ({{Section 7 of QLOG-MAIN}}), each extending the "data" field and
 defining their "name" field and semantics.
 
-{{h3-events}} summarizes the name value of each event type that is defined
-in this specification.
+{{h3-events}} summarizes the name value of each event type that is defined in
+this specification. Some event data fields use complex datastructures. These are
+represented as enums or re-usable definitions, which are grouped together on the
+bottom of this document for clarity.
 
 | Name value                | Importance |  Definition |
 |:--------------------------|:-----------|:------------|
@@ -95,6 +97,20 @@ in this specification.
 | h3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
 | h3:push_resolved          | Extra      | {{h3-pushresolved}} |
 {: #h3-events title="HTTP/3 Events"}
+
+## Usage with QUIC
+
+The events described in this document can be used with or without logging the
+related QUIC events defined in {{QLOG-QUIC}}. If used with QUIC events, the QUIC
+document takes precedence in terms of recommended filenames and trace separation
+setups.
+
+If used without QUIC events, it is recommended that the implementation assign a
+globally unique identifier to each HTTP/3 connection. This ID can then be used as
+the value of the qlog "group_id" field, as well as the qlog filename or file
+identifier, potentially suffixed by the vantagepoint type (For example,
+abcd1234_server.qlog would contain the server-side trace of the connection with
+GUID abcd1234).
 
 ## Notational Conventions
 

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -75,10 +75,10 @@ containing concrete events for the core HTTP/3 protocol {{RFC9114}} and selected
 extensions ({{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}}, and
 {{!H3-DATAGRAM=RFC9297}}).
 
-The schema namespace `http` is defined, containing the category `h3`; see
+The event schema namespace `http` is defined, containing the category `h3`; see
 {{schema-def}}. In this category multiple events derive from the qlog abstract
-Event class ({{Section 7 of QLOG-MAIN}}), each extending the "data" field and
-defining their "name" field and semantics.
+Event class ({{Section 7 of QLOG-MAIN}}),  each extending the "data" field and
+defining their "name" field values and semantics
 
 {{h3-events}} summarizes the name value of each event type that is defined in
 this specification. Some event data fields use complex datastructures. These are
@@ -721,7 +721,7 @@ document as well.
 This document registers a new entry in the "qlog event category URIs" registry.
 
 Event Category URI:
-: urn:ietf:params:qlog:event:http#h3
+: urn:ietf:params:qlog:events:http#h3
 
 Description:
 : Event definitions related to the HTTP/3 application protocol.

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -739,7 +739,8 @@ Universities.
 
 Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
 Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, Christian Huitema and Hugo Landau for their feedback and suggestions.
+Yamamoto, Christian Huitema, Hugo Landau and Jonathan Lennox for their feedback
+and suggestions.
 
 # Change Log
 {:numbered="false" removeinrfc="true"}

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -98,6 +98,14 @@ bottom of this document for clarity.
 | h3:push_resolved          | Extra      | {{h3-pushresolved}} |
 {: #h3-events title="HTTP/3 Events"}
 
+When any event from this document is included in a qlog trace, the
+"protocol_type" qlog array field MUST contain an entry with the value "HTTP3":
+
+~~~ cddl
+$ProtocolType /= "HTTP3"
+~~~
+{: #protocoltype-extension-h3 title="ProtocolType extension for HTTP/3"}
+
 ## Usage with QUIC
 
 The events described in this document can be used with or without logging the

--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -50,9 +50,8 @@ informative:
 
 --- abstract
 
-This document describes concrete qlog event definitions and their metadata for
-HTTP/3-related events. These events can then be embedded in the higher
-level schema defined in {{QLOG-MAIN}}.
+This document defines a qlog event schema containing concrete events for the
+core HTTP/3 protocol and selected extensions.
 
 --- note_Note_to_Readers
 
@@ -71,10 +70,31 @@ various programming languages can be found at
 
 # Introduction
 
-This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the HTTP/3 protocol {{RFC9114}} and some
-of extensions (see {{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}}
-and {{!H3-DATAGRAM=RFC9297}}).
+This document defines a qlog event schema ({{Section 8 of QLOG-MAIN}})
+containing concrete events for the core HTTP/3 protocol {{RFC9114}} and selected
+extensions ({{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}}, and
+{{!H3-DATAGRAM=RFC9297}}).
+
+The schema namespace `http` is defined, containing the category `h3`; see
+{{schema-def}}. In this category multiple events derive from the qlog abstract
+Event class ({{Section 7 of QLOG-MAIN}}), each extending the "data" field and
+defining their "name" field and semantics.
+
+{{h3-events}} summarizes the name value of each event type that is defined
+in this specification.
+
+| Name value                | Importance |  Definition |
+|:--------------------------|:-----------|:------------|
+| h3:parameters_set         | Base       | {{h3-parametersset}} |
+| h3:parameters_restored    | Base       | {{h3-parametersrestored}} |
+| h3:stream_type_set        | Base       | {{h3-streamtypeset}} |
+| h3:priority_updated       | Base       | {{h3-priorityupdated}} |
+| h3:frame_created          | Core       | {{h3-framecreated}} |
+| h3:frame_parsed           | Core       | {{h3-frameparsed}} |
+| h3:datagram_created       | Base       | {{h3-datagramcreated}} |
+| h3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
+| h3:push_resolved          | Extra      | {{h3-pushresolved}} |
+{: #h3-events title="HTTP/3 Events"}
 
 ## Notational Conventions
 
@@ -92,62 +112,25 @@ As is the case for {{QLOG-MAIN}}, the qlog schema definitions in this document
 are intentionally agnostic to serialization formats. The choice of format is an
 implementation decision.
 
-# Overview
+# Event Schema Definition {#schema-def}
 
-This document describes how HTTP/3 can be expressed in qlog using the schema
-defined in {{QLOG-MAIN}}. HTTP/3 events are defined with a category, a name (the
-concatenation of "category" and "event"), an "importance", an optional
-"trigger", and "data" fields.
+This document describes how the core HTTP/3 protocol and selected extensions can
+be expressed in qlog using a newly defined event schema. Per the requirements in
+{{Section 8 of QLOG-MAIN}}, this document registers the `http` namespace and
+`h3` category identifiers. The URI is `urn:ietf:params:qlog:events:http#h3`.
 
-Some data fields use complex datastructures. These are represented as enums or
-re-usable definitions, which are grouped together on the bottom of this document
-for clarity.
+## Draft Event Schema Identification
+{:removeinrfc="true"}
 
-When any event from this document is included in a qlog trace, the
-"protocol_type" qlog array field MUST contain an entry with the value "HTTP3":
+Only implementations of the final, published RFC can use the events belonging to
+the category with the URI `urn:ietf:params:qlog:events:http#h3`. Until such an
+RFC exists, implementations MUST NOT identify themselves using this URI.
 
-~~~ cddl
-$ProtocolType /= "HTTP3"
-~~~
-{: #protocoltype-extension-h3 title="ProtocolType extension for HTTP/3"}
+Implementations of draft versions of the event schema MUST append the string
+"-" and the corresponding draft number to the URI. For example, draft 07 of this
+document is identified using the URI `urn:ietf:params:qlog:events:http#h3-07`.
 
-## Usage with QUIC
-
-The events described in this document can be used with or without logging the
-related QUIC events defined in {{QLOG-QUIC}}. If used with QUIC events, the QUIC
-document takes precedence in terms of recommended filenames and trace separation
-setups.
-
-If used without QUIC events, it is recommended that the implementation assign a
-globally unique identifier to each HTTP/3 connection. This ID can then be used as
-the value of the qlog "group_id" field, as well as the qlog filename or file
-identifier, potentially suffixed by the vantagepoint type (For example,
-abcd1234_server.qlog would contain the server-side trace of the connection with
-GUID abcd1234).
-
-# HTTP/3 Event Overview
-
-This document defines events in two categories, written as lowercase to follow
-convention: h3 ({{h3-ev}}).
-
-As described in {{Section 3.4.2 of QLOG-MAIN}}, the qlog "name" field is the
-concatenation of category and type.
-
-{{h3-events}} summarizes the name value of each event type that is defined
-in this specification.
-
-| Name value                  | Importance |  Definition |
-|:----------------------------|:-----------|:------------|
-| h3:parameters_set         | Base       | {{h3-parametersset}} |
-| h3:parameters_restored    | Base       | {{h3-parametersrestored}} |
-| h3:stream_type_set        | Base       | {{h3-streamtypeset}} |
-| h3:priority_updated       | Base       | {{h3-priorityupdated}} |
-| h3:frame_created          | Core       | {{h3-framecreated}} |
-| h3:frame_parsed           | Core       | {{h3-frameparsed}} |
-| h3:datagram_created       | Base       | {{h3-datagramcreated}} |
-| h3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
-| h3:push_resolved          | Extra      | {{h3-pushresolved}} |
-{: #h3-events title="HTTP/3 Events"}
+The category identifier itself is not affected by this requirement.
 
 # HTTP/3 Events {#h3-ev}
 
@@ -711,7 +694,16 @@ document as well.
 
 # IANA Considerations
 
-There are no IANA considerations.
+This document registers a new entry in the "qlog event category URIs" registry.
+
+Event Category URI:
+: urn:ietf:params:qlog:event:http#h3
+
+Description:
+: Event definitions related to the HTTP/3 application protocol.
+
+Reference:
+: This Document
 
 --- back
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -232,17 +232,17 @@ use case. For example, a QUIC packet being sent or received. This document
 declares an abstract Event class ({{abstract-event}}) containing common fields, which
 all concrete events derive from. Concrete events are defined by event schema
 that declare a namespace, consisting of one or more categories, containing one
-or more related event types. For example, this document defines the `std` event
+or more related event types. For example, this document defines the generic event
 schema structured as:
 
-* `std` namespace
-  * `generic` category
+* `gen` namespace
+  * `loglevel` category
     * `error` event type
     * `warning` event type
     * `info` event type
     * `debug` event type
     * `verbose` event type
-  * `simulation` category
+  * `sim` category
     * `scenario` event type
     * `marker` event type
 
@@ -1014,15 +1014,15 @@ a listed category identifier. Tools MUST NOT treat this as an error; see
 {{tooling}}.
 
 In the following hypothetical example, a qlog file contains events belonging to
-the standard event schema ({{std-event-schema}}), an event schema named `rick`
+the standard event schema ({{generic-event-schema}}), an event schema named `rick`
 specified in a hypothetical RFC, and a private event schema named pickle. The
 standardized categories use a URN format, the private categories use a URI with
 domain name.
 
 ~~~
 "event_schemas": [
-  "urn:ietf:params:qlog:events:std#generic,
-  "urn:ietf:params:qlog:events:std#simulation,
+  "urn:ietf:params:qlog:events:gen#loglevel,
+  "urn:ietf:params:qlog:events:gen#sim,
   "urn:ietf:params:qlog:events:rick#roll",
   "urn:ietf:params:qlog:events:rick#astley",
   "urn:ietf:params:qlog:events:rick#moranis",
@@ -1039,8 +1039,8 @@ Event schema defined by RFCs MUST register all categories in the "qlog event
 category URIs" registry and SHOULD use a URN of the form
 `urn:ietf:params:qlog:events:<namespace identifier>#<category identifier>`,
 where `<category identifier>` is globally unique. For example, this document
-defines the standard event schema ({{std-event-schema}}) that uses the `std`
-namespace containing the `generic` and `simulation` categories. Other examples
+defines the standard event schema ({{generic-event-schema}}) that uses the `gen`
+namespace containing the `loglevel` and `sim` categories. Other examples
 of event schema define the `quic` {{QLOG-QUIC}} and `h3` {{QLOG-H3}} namespaces.
 
 Private or non-standard event categories can use other URI formats. URIs that
@@ -1300,29 +1300,29 @@ additional events is typically avoided. Exceptions have been made for common
 events that benefit from being easily identifiable or individually logged (for
 example `packets_acked`).
 
-# The Standard Event Schema {#std-event-schema}
+# The Generic Event Schema {#generic-event-schema}
 
-The standard event schema defines categories and event types that are common across
-protocols, applications, and use cases. The schema namespace is "std".
+The generic event schema defines categories and event types that are common across
+protocols, applications, and use cases. The schema namespace is "gen".
 
-## Generic Events
+## Log Level Events {#loglevel-events}
 
 In typical logging setups, users utilize a discrete number of well-defined logging
-categories, levels or severities to log freeform (string) data. This generic
-events category replicates this approach to allow implementations to fully replace
+categories, levels or severities to log freeform (string) data. The log level
+event category replicates this approach to allow implementations to fully replace
 their existing text-based logging by qlog. This is done by providing events to log
 generic strings for the typical well-known logging levels (error, warning, info,
-debug, verbose). The category identifier is "generic".
+debug, verbose). The category identifier is "loglevel".
 
 ~~~ cddl
-GenericEventData = GenericError /
-                GenericWarning /
-                GenericInfo /
-                GenericDebug
+LogLevelEventData = LogLevelError /
+                    LogLevelWarning /
+                    LogLevelInfo /
+                    LogLevelDebug
 
-$ProtocolEventData /= GenericEventData
+$ProtocolEventData /= LogLevelEventData
 ~~~
-{: #generic-events-def title="GenericEventData and ProtocolEventData extension"}
+{: #loglevel-events-def title="LogLevelEventData and ProtocolEventData extension"}
 
 The event types are further defined below, their identifier is the heading name.
 
@@ -1332,14 +1332,14 @@ Used to log details of an internal error that might not get reflected on the
 wire. It has Core importance level.
 
 ~~~ cddl
-GenericError = {
+LogLevelError = {
     ? code: uint64
     ? message: text
 
-    * $$generic-error-extension
+    * $$loglevel-error-extension
 }
 ~~~
-{: #generic-error-def title="GenericError definition"}
+{: #loglevel-error-def title="LogLevelError definition"}
 
 ### warning
 
@@ -1347,14 +1347,14 @@ Used to log details of an internal warning that might not get reflected on the
 wire. It has Base importance level; see {{importance}}.
 
 ~~~ cddl
-GenericWarning = {
+LogLevelWarning = {
     ? code: uint64
     ? message: text
 
-    * $$generic-warning-extension
+    * $$loglevel-warning-extension
 }
 ~~~
-{: #generic-warning-def title="GenericWarning definition"}
+{: #loglevel-warning-def title="LogLevelWarning definition"}
 
 ### info
 
@@ -1363,13 +1363,13 @@ logging format but still want to support unstructured string messages. The event
 has Extra importance level; see {{importance}}.
 
 ~~~ cddl
-GenericInfo = {
+LogLevelInfo = {
     message: text
 
-    * $$generic-info-extension
+    * $$loglevel-info-extension
 }
 ~~~
-{: #generic-info-def title="GenericInfo definition"}
+{: #loglevel-info-def title="LogLevelInfo definition"}
 
 ### debug
 
@@ -1378,13 +1378,13 @@ logging format but still want to support unstructured string messages. The event
 has Extra importance level; see {{importance}}.
 
 ~~~ cddl
-GenericDebug = {
+LogLevelDebug = {
     message: text
 
-    * $$generic-debug-extension
+    * $$loglevel-debug-extension
 }
 ~~~
-{: #generic-debug-def title="GenericDebug definition"}
+{: #loglevel-debug-def title="LogLevelDebug definition"}
 
 ### verbose
 
@@ -1393,13 +1393,13 @@ logging format but still want to support unstructured string messages. The event
 has Extra importance level; see {{importance}}.
 
 ~~~ cddl
-GenericVerbose = {
+LogLevelVerbose = {
     message: text
 
-    * $$generic-verbose-extension
+    * $$loglevel-verbose-extension
 }
 ~~~
-{: #generic-verbose-def title="GenericVerbose definition"}
+{: #loglevel-verbose-def title="LogLevelVerbose definition"}
 
 ## Simulation Events
 
@@ -1408,7 +1408,7 @@ interoperability or benchmarking tests, in which the test situations can change
 over time. For example, the network bandwidth or latency can vary during the test,
 or the network can be fully disable for a short time. In these setups, it is
 useful to know when exactly these conditions are triggered, to allow for proper
-correlation with other events. The category identifier is "simulation".
+correlation with other events. The category identifier is "sim".
 
 ~~~ cddl
 SimulationEventData = SimulationScenario /
@@ -1915,7 +1915,8 @@ event categories. It has the following format:
 
 | Event Category URI | Description | Reference |
 |||||
-| urn:ietf:params:qlog:events:std#generic | Well-known logging levels for free-form text. | {{generic-events}} |
+| urn:ietf:params:qlog:events:gen#loglevel | Well-known logging levels for free-form text. | {{loglevel-events}} |
+| urn:ietf:params:qlog:events:gen#sim | Events for simulation testing. | {{loglevel-events}} |
 
 
 --- back

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -261,8 +261,7 @@ LogFile = {
     ? description: text
     event_schemas: [+text]
 
-    ; can contain any amount of custom fields
-    * text => any
+    * $$logfile-extensions
 }
 ~~~
 {: #abstract-logfile-def title="LogFile definition"}
@@ -281,6 +280,18 @@ The optional "title" and "description" fields provide additional free-text
 information about the file.
 
 The required "event_schemas" field is described in {{event-types-and-schema}}.
+
+To support adding custom fields in concrete log file schema, the CDDL "group
+socket" "logfile-extensions" is defined. This field acts as a placeholder that
+can later be replaced with newly defined fields by assigning them to the socket
+with the //= operator. For example:
+
+~~~~~~~~
+$$logfile-extensions //= (
+  ? custom_logfile_extension: bool
+)
+~~~~~~~~
+{: #logfile-groupsocket-extension-example title="Example of using a generic CDDL group socket to extend logfile-extensions"}
 
 ## Concrete Log File Schema URI {#schema-uri}
 
@@ -302,20 +313,23 @@ names change ownership. For example,
 A qlog using the QlogFile schema can contain several individual traces and logs
 from multiple vantage points that are in some way related. The top-level element
 in this schema defines only a small set of "header" fields and an array of
-component traces, defined in {{qlog-file-def}} as:
+component traces.  defined in {{qlog-file-def}} as:
 
 ~~~ cddl
 QlogFile = {
-    ? traces: [+ Trace /
+    $$logfile-extensions //= (
+      ? traces: [+ Trace /
                  TraceError]
+    )
 }
 ~~~
 {: #qlog-file-def title="QlogFile definition"}
 
 The QlogFile schema URI is `urn:ietf:params:qlog:file:contained`.
 
-The optional "traces" field contains an array of qlog traces ({{trace}}), each
-of which contain metadata and an array of qlog events ({{abstract-event}}).
+QlogFile extended `$$logfile-extensions` with the optional "traces" field that
+contains an array of qlog traces ({{trace}}), each of which contain metadata and
+an array of qlog events ({{abstract-event}}).
 
 The default serialization format is JSON; see {{format-json}} for guidance
 on populating the "serialization_format" field and other considerations.
@@ -446,15 +460,18 @@ of component traces, defined in {{qlog-file-def}} as:
 
 ~~~ cddl
 QlogFileSeq = {
-    trace: TraceSeq
+    $$logfile-extensions //= (
+      trace: TraceSeq
+    )
 }
 ~~~
 {: #qlog-file-seq-def title="QlogFileSeq definition"}
 
 The QlogFileSeq schema URI is `urn:ietf:params:qlog:file:sequential`.
 
-The required "trace" field contains a singular trace metadata. All qlog events
-in the file are related to this trace; see {{traceseq}}.
+QlogFileSeq extends `$$logfile-extensions` with the required "trace" field
+contains a singular trace metadata. All qlog events in the file are related to
+this trace; see {{traceseq}}.
 
 See {{format-json-seq}} for guidance on populating the
 "serialization_format" field and other serialization considerations.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -992,8 +992,8 @@ fields are "time" and "data", who are divergent by nature.
 
 Concrete event types are defined in event schema, which declare a namespace
 consisting of one or more categories, each containing related event types. This
-document defines the `std` event schema. Other examples are the `quic`
-{{QLOG-QUIC}} and `h3` {{QLOG-H3}} event schema.
+document defines the `std` event schema; see {{std-event-schema}}. Other
+examples are the `quic` {{QLOG-QUIC}} and `h3` {{QLOG-H3}} event schema.
 
 Concrete events MAY extend any part of the abstract Event class, including extending the "data" field ({{data-field}}) of adding custom fields.
 
@@ -1273,7 +1273,7 @@ additional events is typically avoided. Exceptions have been made for common
 events that benefit from being easily identifiable or individually logged (for
 example `packets_acked`).
 
-# The Standard Event Schema
+# The Standard Event Schema {#std-event-schema}
 
 The standard event schema defines categories and event types that are common across
 protocols, applications, and use cases. The schema namespace is "std".

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -997,14 +997,14 @@ examples are the `quic` {{QLOG-QUIC}} and `h3` {{QLOG-H3}} event schema.
 
 Concrete events MAY extend any part of the abstract Event class, including extending the "data" field ({{data-field}}) of adding custom fields.
 
-Event schema MUST define a registered non-empty namespace of type `text`.
+Event schema MUST define a registered non-empty namespace identifier of type `text`.
 
 Event categories MUST belong to a single event schema. The MUST have a
 registered non-empty globally-unique identifier of type `text` and MUST have a
 single dereferencable URI. That URI MUST be absolute and MUST indicate the
 category identifier using a fragment identifier (characters after a "#" in the
 URI). For event categories in schema defined by RFCs, the URI SHOULD be a URN of
-the form `urn:ietf:params:qlog:<schema namespace>#<category identifier>`.
+the form `urn:ietf:params:qlog:events:<namespace identifier>#<category identifier>`.
 Private or non-standard event categories can use other URI formats. URIs that
 contain a domain name SHOULD also contain a month-date in the form mmyyyy. The
 definition of the category and assignment of the URI MUST have been authorized by
@@ -1015,7 +1015,7 @@ The registration requirements for extension schema URIs are detailed in
 {{iana}}.
 
 Concrete event types MUST belong to a single event category and MUST have a
-non-empty identifier of type `text`.
+non-empty name of type `text`.
 
 The value of a qlog event `name` field MUST be the concatenation of category
 identifier, colon (':'), and event type identifier. By virtue of the identifier

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -300,7 +300,9 @@ Concrete log file schemas MUST identify themselves using a URI.
 Log file schemas defined by RFCs MUST register a URI in the "qlog log file
 schema URIs" registry and SHOULD use a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`, where `<schema-identifier>` is
-a globally-unique name.
+a globally-unique name. This document registers
+`urn:ietf:params:qlog:file:contained` ({{qlog-file-schema}}) and
+`urn:ietf:params:qlog:file:sequential` ({{qlog-file-seq-schema}}).
 
 Private or non-standard log file schemas MAY register a URI in the "qlog log
 file schema" registry but MUST NOT use a URN of the form
@@ -313,9 +315,9 @@ names change ownership.
 
 The "qlog log file schema URIs" registry operates under the Expert Review
 policy, per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert
-SHOULD check that the URI is appropriate to the concrete log file format and
+MUST check that the URI is appropriate to the concrete log file format and
 satisfies the requirements in this section. A request to register a private or
-non-standard URI using a URN of the form
+non-standard log schema URI using a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>` MUST be rejected.
 
 Registration requests should use the following template:
@@ -1874,12 +1876,11 @@ IANA Registry Reference:
 
 IANA is requested to create the "qlog log file schema URIs" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
-event extension schema. It has the following format:
+log file schema. It has the following format:
 
 | Log File Schema URI | Description | Reference |
-| urn:ietf:params:qlog:file:contained| Concrete log file format that can contain several traces from multiple vantage points. | This document |
-| urn:ietf:params:qlog:file:sequential| Concrete log file format containing a single trace, optimized for seqential read and write access. | This document |
-
+| urn:ietf:params:qlog:file:contained| Concrete log file format that can contain several traces from multiple vantage points. | {{qlog-file-schema}} |
+| urn:ietf:params:qlog:file:sequential| Concrete log file format containing a single trace, optimized for seqential read and write access. | {{qlog-file-seq-schema}} |
 
 --- back
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -66,8 +66,8 @@ qlog provides extensible structured logging for network protocols, allowing for
 easy sharing of data that benefits common debug and analysis methods and
 tooling. This document describes key concepts of qlog: formats, files, traces,
 events, and extension points. In this definition are the high-level log file
-schemas, and main event schema. Requirements and guidelines for creating
-protocol-specific event schema are also presented. All schema are independent of
+schemas, and standard event schema. Requirements and guidelines for creating
+protocol-specific event schema are also presented. All schemas are independent of
 serialization format, allowing logs to be represented in many ways such as JSON,
 CSV, or protobuf.
 
@@ -232,10 +232,10 @@ use case. For example, a QUIC packet being sent or received. This document
 declares an abstract Event class ({{abstract-event}}) containing common fields, which
 all concrete events derive from. Concrete events are defined by event schema
 that declare a namespace, consisting of one or more categories, containing one
-or more related event types. For example, this document defines the `main` event
+or more related event types. For example, this document defines the `std` event
 schema structured as:
 
-* `main` namespace
+* `std` namespace
   * `generic` category
     * `error` event type
     * `warning` event type
@@ -969,7 +969,7 @@ fields are "time" and "data", who are divergent by nature.
 
 Concrete event types are defined in event schema, which declare a namespace
 consisting of one or more categories, each containing related event types. This
-document defines the `main` event schema. Other examples are the `quic`
+document defines the `std` event schema. Other examples are the `quic`
 {{QLOG-QUIC}} and `h3` {{QLOG-H3}} event schema.
 
 Concrete events MAY extend any part of the abstract Event class, including extending the "data" field ({{data-field}}) of adding custom fields.
@@ -1250,10 +1250,10 @@ additional events is typically avoided. Exceptions have been made for common
 events that benefit from being easily identifiable or individually logged (for
 example `packets_acked`).
 
-# Main Event Schema
+# The Standard Event Schema
 
-The main event schema defines categories and event types that are common across
-protocols, applications, and use cases. The schema namespace is "main".
+The standard event schema defines categories and event types that are common across
+protocols, applications, and use cases. The schema namespace is "std".
 
 ## Generic Events
 
@@ -1279,7 +1279,7 @@ The event types are further defined below, their identifier is the heading name.
 ### error
 
 Used to log details of an internal error that might not get reflected on the
-wire. The event indentifier is `error has Core importance level.
+wire. It has Core importance level.
 
 ~~~ cddl
 GenericError = {

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -293,10 +293,10 @@ a globally-unique name. This document registers
 `urn:ietf:params:qlog:file:sequential` ({{qlog-file-seq-schema}}).
 
 Private or non-standard log file schemas MAY register a URI in the "qlog log
-file schema" registry but MUST NOT use a URN of the form
+file schema URIs" registry but MUST NOT use a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`. URIs that contain a domain name
 SHOULD also contain a month-date in the form mmyyyy. For example,
-"https://example.org/072024/customfileschema". The definition of the log file
+"https://example.org/072024/globallyuniquefileschema". The definition of the log file
 schema and assignment of the URI MUST have been authorized by the owner of the
 domain name on or very close to that date. This avoids problems when domain
 names change ownership.
@@ -1043,8 +1043,12 @@ defines the standard event schema ({{generic-event-schema}}) that uses the `gen`
 namespace containing the `loglevel` and `sim` categories. Other examples
 of event schema define the `quic` {{QLOG-QUIC}} and `h3` {{QLOG-H3}} namespaces.
 
-Private or non-standard event categories can use other URI formats. URIs that
-contain a domain name SHOULD also contain a month-date in the form mmyyyy. The
+Private or non-standard event categories MAY be registered in the "qlog event
+category URIs" registry but MUST NOT use a URN of the form
+`urn:ietf:params:qlog:events:<namespace identifier>#<category identifier>`. URIs
+that contain a domain name SHOULD also contain a month-date in the form mmyyyy.
+For example,
+"https://example.org/072024/customeventchema#globallyuniquencategory" The
 definition of the category and assignment of the URI MUST have been authorized
 by the owner of the domain name on or very close to that date. This avoids
 problems when domain names change ownership.
@@ -1053,7 +1057,7 @@ The "qlog event category URIs" registry operates under the Expert Review policy,
 per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert MUST check
 that the URI is appropriate to the event schema and satisfies the requirements
 in {{event-types-and-schema}} and this section. A request to register a private
-or non-standard log schema URI using a URN of the form
+or non-standard category URI using a URN of the form
 `urn:ietf:params:qlog:event:<namespace identifier>#<category identifier` MUST be
 rejected.
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1949,7 +1949,8 @@ Universities.
 
 Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
 Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, Christian Huitema and Hugo Landau for their feedback and suggestions.
+Yamamoto, Christian Huitema, Hugo Landau and Jonathan Lennox for their feedback
+and suggestions.
 
 # Change Log
 {:numbered="false" removeinrfc="true"}

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -293,20 +293,41 @@ $$logfile-extensions //= (
 ~~~~~~~~
 {: #logfile-groupsocket-extension-example title="Example of using a generic CDDL group socket to extend logfile-extensions"}
 
-## Concrete Log File Schema URI {#schema-uri}
+## Concrete Log File Schema URIs {#schema-uri}
 
 Concrete log file schemas MUST identify themselves using a URI.
 
-Log file schemas defined by RFCs SHOULD be URN of the form
+Log file schemas defined by RFCs MUST register a URI in the "qlog log file
+schema URIs" registry and SHOULD use a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`, where `<schema-identifier>` is
-a globally-unique name. URN MUST be registered with IANA; see {{iana}}.
+a globally-unique name.
 
-Private or non-standard log file schemas can use other URI formats. URIs that
-contain a domain name SHOULD also contain a month-date in the form mmyyyy. For
-example, "https://example.org/072024/customfileschema". The definition of the
-file schema and assignment of the URI MUST have been authorized by the owner of
-the domain name on or very close to that date. This avoids problems when domain
-names change ownership. For example,
+Private or non-standard log file schemas MAY register a URI in the "qlog log
+file schema" registry but MUST NOT use a URN of the form
+`urn:ietf:params:qlog:file:<schema-identifier>`. URIs that contain a domain name
+SHOULD also contain a month-date in the form mmyyyy. For example,
+"https://example.org/072024/customfileschema". The definition of the log file
+schema and assignment of the URI MUST have been authorized by the owner of the
+domain name on or very close to that date. This avoids problems when domain
+names change ownership.
+
+The "qlog log file schema URIs" registry operates under the Expert Review
+policy, per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert
+SHOULD check that the URI is appropriate to the concrete log file format and
+satisfies the requirements in this section. A request to register a private or
+non-standard URI using a URN of the form
+`urn:ietf:params:qlog:file:<schema-identifier>` MUST be rejected.
+
+Registration requests should use the following template:
+
+Log File Schema URI:
+: \[the log file schema identifier\]
+
+Description:
+: \[a description of the log file schema\]
+
+Reference:
+: \[to a specification defining the log file schema\]
 
 # QlogFile schema {#qlog-file-schema}
 
@@ -1839,7 +1860,26 @@ inclusion of such fields for all but the most stringent use cases.
 
 # IANA Considerations {#iana}
 
-TODO: file and event schema registration stuff
+IANA is requested to register a new entry in the "IETF URN Sub-namespace for
+Registered Protocol Parameter Identifiers" registry ({{!RFC3553}})":
+
+Registered Parameter Identifier:
+: qlog
+
+Reference:
+: This Document
+
+IANA Registry Reference:
+: [](https://www.iana.org/assignments/qlog){: brackets="angle"}
+
+IANA is requested to create the "qlog log file schema URIs" registry
+at [](https://www.iana.org/assignments/qlog) for the purpose of registering
+event extension schema. It has the following format:
+
+| Log File Schema URI | Description | Reference |
+| urn:ietf:params:qlog:file:contained| Concrete log file format that can contain several traces from multiple vantage points. | This document |
+| urn:ietf:params:qlog:file:sequential| Concrete log file format containing a single trace, optimized for seqential read and write access. | This document |
+
 
 --- back
 

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -283,12 +283,13 @@ in {{event-types-and-schema}}.
 
 ## Concrete Log File Schema URIs {#schema-uri}
 
-Concrete log file schemas MUST identify themselves using a URI.
+Concrete log file schemas MUST identify themselves using a URI {{!RFC3986}}.
 
 Log file schemas defined by RFCs MUST register a URI in the "qlog log file
 schema URIs" registry and SHOULD use a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`, where `<schema-identifier>` is
-a globally-unique name. This document registers
+a globally-unique text name using only characters in the URI unreserved range;
+see {{Section 2.3 of RFC3986}}. This document registers
 `urn:ietf:params:qlog:file:contained` ({{qlog-file-schema}}) and
 `urn:ietf:params:qlog:file:sequential` ({{qlog-file-seq-schema}}).
 
@@ -296,10 +297,12 @@ Private or non-standard log file schemas MAY register a URI in the "qlog log
 file schema URIs" registry but MUST NOT use a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`. URIs that contain a domain name
 SHOULD also contain a month-date in the form mmyyyy. For example,
-"https://example.org/072024/globallyuniquefileschema". The definition of the log file
-schema and assignment of the URI MUST have been authorized by the owner of the
-domain name on or very close to that date. This avoids problems when domain
-names change ownership.
+"https://example.org/072024/globallyuniquefileschema". The definition of the log
+file schema and assignment of the URI MUST have been authorized by the owner of
+the domain name on or very close to that date. This avoids problems when domain
+names change ownership. The URI does not need to be dereferencable, allowing for
+confidential use or to cover the case where the log file schema continues to be
+used after the organization that defined them ceases to exist.
 
 The "qlog log file schema URIs" registry operates under the Expert Review
 policy, per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert
@@ -982,14 +985,17 @@ Concrete event types belong to event categories, both defined by event schema.
 
 A single event schema can define a new namespace, or extend an existing
 namespace with new categories. New namespaces MUST be registered using a
-non-empty namespace identifier of type `text`. Namespace are mutable and MAY be
-extended with categories.
+non-empty namespace identifier text identifier using only characters in the
+unreserved range; see {{Section 2.3 of RFC3986}}. Namespace are mutable and MAY
+be extended with categories.
 
 Event categories MUST belong to a single event namespace. They MUST have a
-registered non-empty globally-unique identifier of type `text` and MUST have a
-single dereferencable URI. That URI MUST be absolute and MUST indicate the
-category identifier using a fragment identifier (characters after a "#" in the
-URI). Event categories are immutable and MUST NOT be extended with events.
+registered non-empty globally-unique text identifier only characters in the
+URI unreserved range; see {{Section 2.3 of RFC3986}}. They MUST have a single URI
+{{RFC3986}} that MUST be absolute. The URI MUST include the namespace
+identifier. The URI MUST include the category identifer using a fragment
+identifier (characters after a "#" in the URI). Event categories are immutable
+and MUST NOT be extended with events.
 
 Registration guidance and requirements is provided in {{event-schema-reg}}.
 
@@ -1051,7 +1057,10 @@ For example,
 "https://example.org/072024/customeventchema#globallyuniquencategory" The
 definition of the category and assignment of the URI MUST have been authorized
 by the owner of the domain name on or very close to that date. This avoids
-problems when domain names change ownership.
+problems when domain names change ownership. The URI does not need to be
+dereferencable, allowing for confidential use or to cover the case where the log
+file schema continues to be used after the organization that defined them ceases
+to exist.
 
 The "qlog event category URIs" registry operates under the Expert Review policy,
 per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert MUST check

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -250,8 +250,8 @@ schema structured as:
 
 A Log file is intended to contain a collection of events that are in some way
 related. An abstract LogFile class containing fields common to all log files is
-defined. Each concrete log file format derives from this, extending it by
-defining semantics and any custom fields.
+defined. Each concrete log file format derives from this using the CDDL unwrap
+operator (~) and extending it by defining semantics and any custom fields.
 
 ~~~ cddl
 LogFile = {
@@ -260,8 +260,6 @@ LogFile = {
     ? title: text
     ? description: text
     event_schemas: [+text]
-
-    * $$logfile-extensions
 }
 ~~~
 {: #abstract-logfile-def title="LogFile definition"}
@@ -282,18 +280,6 @@ information about the file.
 The required "event_schemas" field contains event schema URI that identify
 concrete event types recorded in a log. Requirements and guidelines are defined
 in {{event-types-and-schema}}.
-
-To support adding custom fields in concrete log file schema, the CDDL "group
-socket" "logfile-extensions" is defined. This field acts as a placeholder that
-can later be replaced with newly defined fields by assigning them to the socket
-with the //= operator. For example:
-
-~~~~~~~~
-$$logfile-extensions //= (
-  ? custom_logfile_extension: bool
-)
-~~~~~~~~
-{: #logfile-groupsocket-extension-example title="Example of using a generic CDDL group socket to extend logfile-extensions"}
 
 ## Concrete Log File Schema URIs {#schema-uri}
 
@@ -342,19 +328,19 @@ component traces.  defined in {{qlog-file-def}} as:
 
 ~~~ cddl
 QlogFile = {
-    $$logfile-extensions //= (
-      ? traces: [+ Trace /
-                 TraceError]
-    )
+    ~LogFile
+    ? traces: [+ Trace /
+                TraceError]
 }
 ~~~
 {: #qlog-file-def title="QlogFile definition"}
 
 The QlogFile schema URI is `urn:ietf:params:qlog:file:contained`.
 
-QlogFile extended `$$logfile-extensions` with the optional "traces" field that
-contains an array of qlog traces ({{trace}}), each of which contain metadata and
-an array of qlog events ({{abstract-event}}).
+QlogFile extends LogFile using the CDDL unwrap operator (~), which copies the
+fields presented in {{abstract-logfile}}. Additionally, the optional "traces"
+field contains an array of qlog traces ({{trace}}), each of which contain
+metadata and an array of qlog events ({{abstract-event}}).
 
 The default serialization format is JSON; see {{format-json}} for guidance
 on populating the "serialization_format" field and other considerations.
@@ -485,18 +471,18 @@ of component traces, defined in {{qlog-file-def}} as:
 
 ~~~ cddl
 QlogFileSeq = {
-    $$logfile-extensions //= (
-      trace: TraceSeq
-    )
+    ~LogFile
+    trace: TraceSeq
 }
 ~~~
 {: #qlog-file-seq-def title="QlogFileSeq definition"}
 
 The QlogFileSeq schema URI is `urn:ietf:params:qlog:file:sequential`.
 
-QlogFileSeq extends `$$logfile-extensions` with the required "trace" field
-contains a singular trace metadata. All qlog events in the file are related to
-this trace; see {{traceseq}}.
+QlogFile extends LogFile using the CDDL unwrap operator (~), which copies the
+fields presented in {{abstract-logfile}}. Additionally, the required "trace"
+field contains a singular trace metadata. All qlog events in the file are
+related to this trace; see {{traceseq}}.
 
 See {{format-json-seq}} for guidance on populating the
 "serialization_format" field and other serialization considerations.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -259,7 +259,7 @@ LogFile = {
     serialization_format: text
     ? title: text
     ? description: text
-    event_schema: [+text]
+    event_schemas: [+text]
 
     ; can contain any amount of custom fields
     * text => any

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -256,7 +256,7 @@ defining semantics and any custom fields.
 ~~~ cddl
 LogFile = {
     file_schema: text
-    qlog_serialization_format: text
+    serialization_format: text
     ? title: text
     ? description: text
     event_schema: [+text]
@@ -270,11 +270,11 @@ LogFile = {
 The required "file_schema" field identifies the concrete log file format. It
 MUST have a value that is an absolute URI; see {{schema-uri}} for rules and
 guidance. In order to make it easier to parse and identify qlog files and their
-serialization format, the "file_schema" and "qlog_serialization_format" fields
+serialization format, the "file_schema" and "serialization_format" fields
 and their values SHOULD be in the first 256 characters/bytes of the resulting
 log file.
 
-The required "qlog_serialization_format" field indicates the serialization
+The required "serialization_format" field indicates the serialization
 format using a media type {{!RFC2046}}. It is case-insensitive.
 
 The optional "title" and "description" fields provide additional free-text
@@ -318,7 +318,7 @@ The optional "traces" field contains an array of qlog traces ({{trace}}), each
 of which contain metadata and an array of qlog events ({{abstract-event}}).
 
 The default serialization format is JSON; see {{format-json}} for guidance
-on populating the "qlog_serialization_format" field and other considerations.
+on populating the "serialization_format" field and other considerations.
 Where a qlog file is serialized to a JSON format, one of the downsides is that
 it is inherently a non-streamable format. Put differently, it is not possible to
 simply append new qlog events to a log file without "closing" this file at the
@@ -331,7 +331,7 @@ JSON serialization example:
 ~~~
 {
     "file_schema": "urn:ietf:params:qlog:file:contained",
-    "qlog_serialization_format": "application/qlog+json",
+    "serialization_format": "application/qlog+json",
     "title": "Name of this particular qlog file (short)",
     "description": "Description for this group of traces (long)",
     "traces": [...]
@@ -457,7 +457,7 @@ The required "trace" field contains a singular trace metadata. All qlog events
 in the file are related to this trace; see {{traceseq}}.
 
 See {{format-json-seq}} for guidance on populating the
-"qlog_serialization_format" field and other serialization considerations.
+"serialization_format" field and other serialization considerations.
 
 JSON-SEQ serialization example:
 
@@ -469,7 +469,7 @@ JSON-SEQ serialization example:
 
 <RS>{
     "file_schema": "urn:ietf:params:qlog:file:sequential",
-    "qlog_serialization_format": "application/qlog+json-seq",
+    "serialization_format": "application/qlog+json-seq",
     "title": "Name of JSON Text Sequence qlog file (short)",
     "description": "Description for this trace file (long)",
     "trace": {
@@ -1458,7 +1458,7 @@ interoperability considerations for both formats, and {{optimizations}} presents
 potential optimizations.
 
 Serialization formats require appropriate deserializers/parsers. The
-"qlog_serialization_format" field ({{abstract-logfile}}}) is used to indicate the chosen
+"serialization_format" field ({{abstract-logfile}}) is used to indicate the chosen
 serialization format.
 
 ## qlog to JSON mapping {#format-json}

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -280,17 +280,17 @@ format using a media type {{!RFC2046}}. It is case-insensitive.
 The optional "title" and "description" fields provide additional free-text
 information about the file.
 
-The required "event_schema" field is described in {{event-types-and-schema}}.
+The required "event_schemas" field is described in {{event-types-and-schema}}.
 
-## Concrete Schema URI {#schema-uri}
+## Concrete Log File Schema URI {#schema-uri}
 
 Concrete log file schemas MUST identify themselves using a URI.
 
-Log schemas defined by RFCs SHOULD be URN of the form
+Log file schemas defined by RFCs SHOULD be URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>`, where `<schema-identifier>` is
 a globally-unique name. URN MUST be registered with IANA; see {{iana}}.
 
-Private or non-standard event categories can use other URI formats. URIs that
+Private or non-standard log file schemas can use other URI formats. URIs that
 contain a domain name SHOULD also contain a month-date in the form mmyyyy. For
 example, "https://example.org/072024/customfileschema". The definition of the
 file schema and assignment of the URI MUST have been authorized by the owner of

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2301,7 +2301,8 @@ Universities.
 
 Thanks to Jana Iyengar, Brian Trammell, Dmitri Tikhonov, Stephen Petrides, Jari
 Arkko, Marcus Ihlar, Victor Vasiliev, Mirja Kühlewind, Jeremy Lainé, Kazu
-Yamamoto, Christian Huitema and Hugo Landau for their feedback and suggestions.
+Yamamoto, Christian Huitema, Hugo Landau and Jonathan Lennox for their feedback
+and suggestions.
 
 # Change Log
 {:numbered="false" removeinrfc="true"}

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -71,13 +71,14 @@ containing concrete events for the core QUIC protocol (see
 {{!QUIC-TLS=RFC9001}}) and some of its extensions (see
 {{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
 
-The schema namespace `quic` is defined, containing the categories:
+The event schema namespace `quic` is defined, containing the categories:
 `connectivity` ({{conn-ev}}), `security` ({{sec-ev}}), `quic` {{quic-ev}}, and
 `recovery` {{rec-ev}}. Across these categories multiple events derive from the
 qlog abstract Event class ({{Section 7 of QLOG-MAIN}}), each extending the
-"data" field and defining their "name" field and semantics. Some data fields use
-complex datastructures. These are represented as enums or re-usable definitions,
-which are grouped together on the bottom of this document for clarity.
+"data" field and defining their "name" field values and semantics. Some data
+fields use complex datastructures. These are represented as enums or re-usable
+definitions, which are grouped together on the bottom of this document for
+clarity.
 
 When any event from this document is included in a qlog trace, the
 `protocol_type` qlog array field MUST contain an entry with the value "QUIC":
@@ -145,7 +146,8 @@ implementation decision.
 
 This document describes how the core QUIC protocol and selected extensions can
 be expressed in qlog using a newly defined event schema. Per the requirements in
-{{Section 8 of QLOG-MAIN}}, this document registers the `quic` namespace and the following category identifiers and URIs.
+{{Section 8 of QLOG-MAIN}}, this document registers the `quic` namespace and the
+following category identifiers and URIs.
 
 * `connectivity` - `urn:ietf:params:qlog:events:quic#connectivity`
 * `security` - `urn:ietf:params:qlog:events:quic#security`
@@ -156,7 +158,7 @@ be expressed in qlog using a newly defined event schema. Per the requirements in
 {:removeinrfc="true"}
 
 Only implementations of the final, published RFC can use the events belonging to
-the category with the URI `urn:ietf:params:qlog:events:quic#connectivity`,
+the category with the URIs `urn:ietf:params:qlog:events:quic#connectivity`,
 `urn:ietf:params:qlog:events:quic#security`,
 `urn:ietf:params:qlog:events:quic#quic`, and
 `urn:ietf:params:qlog:events:quic#recovery`. Until such an RFC exists,
@@ -2250,10 +2252,11 @@ document as well.
 
 # IANA Considerations
 
-This document registers several new entries in the "qlog event category URIs" registry.
+This document registers several new entries in the "qlog event category URIs"
+registry.
 
 Event Category URI:
-: urn:ietf:params:qlog:event:quic#connectivity
+: urn:ietf:params:qlog:events:quic#connectivity
 
 Description:
 : Event definitions related to QUIC connectivity.
@@ -2262,7 +2265,7 @@ Reference:
 : {{conn-ev}}
 
 Event Category URI:
-: urn:ietf:params:qlog:event:quic#security
+: urn:ietf:params:qlog:events:quic#security
 
 Description:
 : Event definitions related to QUIC security.
@@ -2271,7 +2274,7 @@ Reference:
 : {{sec-ev}}
 
 Event Category URI:
-: urn:ietf:params:qlog:event:quic#quic
+: urn:ietf:params:qlog:events:quic#quic
 
 Description:
 : Event definitions related to the QUIC wire image and other concerns.
@@ -2280,7 +2283,7 @@ Reference:
 : {{quic-ev}}
 
 Event Category URI:
-: urn:ietf:params:qlog:event:quic#recovery
+: urn:ietf:params:qlog:events:quic#recovery
 
 Description:
 : Event definitions related to QUIC recovery.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -44,9 +44,9 @@ informative:
 
 --- abstract
 
-This document describes concrete qlog event definitions and their metadata for
-QUIC events. These events can then be embedded in the higher level schema defined
-in {{QLOG-MAIN}}.
+This document describes a qlog event schema containing concrete qlog event
+definitions and their metadata for the core QUIC protocol and selected
+extensions.
 
 --- note_Note_to_Readers
 
@@ -65,38 +65,19 @@ various programming languages can be found at
 
 # Introduction
 
-This document describes the values of the qlog name ("category" + "event") and
-"data" fields and their semantics for the QUIC protocol (see
+This document defines a qlog event schema ({{Section 8 of QLOG-MAIN}})
+containing concrete events for the core QUIC protocol (see
 {{!QUIC-TRANSPORT=RFC9000}}, {{!QUIC-RECOVERY=RFC9002}}, and
 {{!QUIC-TLS=RFC9001}}) and some of its extensions (see
 {{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
 
-## Notational Conventions
-
-{::boilerplate bcp14-tagged}
-
-The event and data structure definitions in ths document are expressed
-in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
-extensions described in {{QLOG-MAIN}}.
-
-The following fields from {{QLOG-MAIN}} are imported and used: name, category,
-type, data, group_id, protocol_type, importance, RawInfo, and time-related
-fields.
-
-As is the case for {{QLOG-MAIN}}, the qlog schema definitions in this document
-are intentionally agnostic to serialization formats. The choice of format is an
-implementation decision.
-
-# Overview
-
-This document describes how the QUIC protocol can be expressed in qlog using
-the schema defined in {{QLOG-MAIN}}. QUIC protocol events are defined with a
-category, a name (the concatenation of "category" and "event"), an "importance",
-an optional "trigger", and "data" fields.
-
-Some data fields use complex datastructures. These are represented as enums or
-re-usable definitions, which are grouped together on the bottom of this document
-for clarity.
+The schema namespace `quic` is defined, containing the categories:
+`connectivity` ({{conn-ev}}), `security` ({{sec-ev}}), `quic` {{quic-ev}}, and
+`recovery` {{rec-ev}}. Across these categories multiple events derive from the
+qlog abstract Event class ({{Section 7 of QLOG-MAIN}}), each extending the
+"data" field and defining their "name" field and semantics. Some data fields use
+complex datastructures. These are represented as enums or re-usable definitions,
+which are grouped together on the bottom of this document for clarity.
 
 When any event from this document is included in a qlog trace, the
 `protocol_type` qlog array field MUST contain an entry with the value "QUIC":
@@ -105,6 +86,8 @@ When any event from this document is included in a qlog trace, the
 $ProtocolType /= "QUIC"
 ~~~
 {: #protocoltype-extension-quic title="ProtocolType extension for QUIC"}
+
+## Use of group IDs
 
 When the qlog `group_id` field is used, it is recommended to use QUIC's Original
 Destination Connection ID (ODCID, the CID chosen by the client when first
@@ -142,15 +125,50 @@ implementation. Some options include:
 * Buffer events until they can be assigned to a connection (for example for
   version negotiation and retry events).
 
+## Notational Conventions
+
+{::boilerplate bcp14-tagged}
+
+The event and data structure definitions in ths document are expressed
+in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
+extensions described in {{QLOG-MAIN}}.
+
+The following fields from {{QLOG-MAIN}} are imported and used: name, category,
+type, data, group_id, protocol_type, importance, RawInfo, and time-related
+fields.
+
+As is the case for {{QLOG-MAIN}}, the qlog schema definitions in this document
+are intentionally agnostic to serialization formats. The choice of format is an
+implementation decision.
+
+# Event Schema Definition {#schema-def}
+
+This document describes how the core QUIC protocol and selected extensions can
+be expressed in qlog using a newly defined event schema. Per the requirements in
+{{Section 8 of QLOG-MAIN}}, this document registers the `quic` namespace and the following category identifiers and URIs.
+
+* `connectivity` - `urn:ietf:params:qlog:events:quic#connectivity`
+* `security` - `urn:ietf:params:qlog:events:quic#security`
+* `quic` - `urn:ietf:params:qlog:events:quic#quic`
+* `recovery` - `urn:ietf:params:qlog:events:quic#recovery`
+
+## Draft Event Schema Identification
+{:removeinrfc="true"}
+
+Only implementations of the final, published RFC can use the events belonging to
+the category with the URI `urn:ietf:params:qlog:events:quic#connectivity`,
+`urn:ietf:params:qlog:events:quic#security`,
+`urn:ietf:params:qlog:events:quic#quic`, and
+`urn:ietf:params:qlog:events:quic#recovery`. Until such an RFC exists,
+implementations MUST NOT identify themselves using this URI.
+
+Implementations of draft versions of the event schema MUST append the string
+"-" and the corresponding draft number to the URI. For example, draft 07 of this
+document is identified using the URI `urn:ietf:params:qlog:events:quic#quic-07`.
+
+The category identifier itself is not affected by this requirement.
+
 # QUIC Event Overview
-
-QUIC connections consist of different phases and interaction events. In order to
-model this, QUIC event types are divided into general categories: connectivity
-({{conn-ev}}), security ({{sec-ev}}), quic {{quic-ev}}, and recovery
-{{rec-ev}}.
-
-As described in {{Section 3.4.2 of QLOG-MAIN}}, the qlog `name` field is the
-concatenation of category and type.
 
 {{quic-events}} summarizes the name value of each event type that is defined in
 this specification.
@@ -2232,7 +2250,43 @@ document as well.
 
 # IANA Considerations
 
-There are no IANA considerations.
+This document registers several new entries in the "qlog event category URIs" registry.
+
+Event Category URI:
+: urn:ietf:params:qlog:event:quic#connectivity
+
+Description:
+: Event definitions related to QUIC connectivity.
+
+Reference:
+: {{conn-ev}}
+
+Event Category URI:
+: urn:ietf:params:qlog:event:quic#security
+
+Description:
+: Event definitions related to QUIC security.
+
+Reference:
+: {{sec-ev}}
+
+Event Category URI:
+: urn:ietf:params:qlog:event:quic#quic
+
+Description:
+: Event definitions related to the QUIC wire image and other concerns.
+
+Reference:
+: {{quic-ev}}
+
+Event Category URI:
+: urn:ietf:params:qlog:event:quic#recovery
+
+Description:
+: Event definitions related to QUIC recovery.
+
+Reference:
+: {{conn-ev}}
 
 --- back
 


### PR DESCRIPTION
This looks like hell to review but a lot of it is moving text around, so a visual diff is probably the most straightforward.

The high-level (pun-intended) goal of this PR is to realize the `main-schema` document is not merely a schema. Its the document that defines the core concepts behind its structured logging, methodology, requirements for loggers and tools, AND a few schema. 
Moving the document away from referring to its entire self as a schema, makes it easier to isolate the parts we mostly expect people to extend - the event definitions.

I found it incredibly hard to talk about this with the old terminology of generic event class and specific data. Especially when combined with the concept of "event definition documents". That's been reflected into prior attempts at wrangling the extensibility of events. So I've changed that to abstract Event class and concrete event types. I suspect those won't be that popular either but they work for this old OOP survivor. 

The PR isn't 100% complete but it does implement the schema > category > event structure that we seemed to align on, and ports over a lot more from https://github.com/quicwg/qlog/pull/415. If we think this is a suitable direction, putting the finishing touches like IANA policy and updating QUIC/H3 docs isn't that much more work.