### PR TITLE
Remove categories

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -77,27 +77,27 @@ containing concrete events for the core HTTP/3 protocol {{RFC9114}} and selected
 extensions ({{!EXTENDED-CONNECT=RFC9220}}, {{!H3_PRIORITIZATION=RFC9218}}, and
 {{!H3-DATAGRAM=RFC9297}}).
 
-The event schema namespace `http` is defined, containing the category `h3`; see
-{{schema-def}}. In this category multiple events derive from the qlog abstract
-Event class ({{Section 7 of QLOG-MAIN}}),  each extending the "data" field and
-defining their "name" field values and semantics
+The event namespace with identifier `http3` is defined; see {{schema-def}}. In
+this namespace multiple events derive from the qlog abstract Event class
+({{Section 7 of QLOG-MAIN}}), each extending the "data" field and defining
+their "name" field values and semantics.
 
 {{h3-events}} summarizes the name value of each event type that is defined in
-this specification. Some event data fields use complex datastructures. These are
+this specification. Some event data fields use complex data types. These are
 represented as enums or re-usable definitions, which are grouped together on the
 bottom of this document for clarity.
 
-| Name value                | Importance |  Definition |
-|:--------------------------|:-----------|:------------|
-| h3:parameters_set         | Base       | {{h3-parametersset}} |
-| h3:parameters_restored    | Base       | {{h3-parametersrestored}} |
-| h3:stream_type_set        | Base       | {{h3-streamtypeset}} |
-| h3:priority_updated       | Base       | {{h3-priorityupdated}} |
-| h3:frame_created          | Core       | {{h3-framecreated}} |
-| h3:frame_parsed           | Core       | {{h3-frameparsed}} |
-| h3:datagram_created       | Base       | {{h3-datagramcreated}} |
-| h3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
-| h3:push_resolved          | Extra      | {{h3-pushresolved}} |
+| Name value                   | Importance |  Definition |
+|:-----------------------------|:-----------|:------------|
+| http3:parameters_set         | Base       | {{h3-parametersset}} |
+| http3:parameters_restored    | Base       | {{h3-parametersrestored}} |
+| http3:stream_type_set        | Base       | {{h3-streamtypeset}} |
+| http3:priority_updated       | Base       | {{h3-priorityupdated}} |
+| http3:frame_created          | Core       | {{h3-framecreated}} |
+| http3:frame_parsed           | Core       | {{h3-frameparsed}} |
+| http3:datagram_created       | Base       | {{h3-datagramcreated}} |
+| http3:datagram_parsed        | Base       | {{h3-datagramparsed}} |
+| http3:push_resolved          | Extra      | {{h3-pushresolved}} |
 {: #h3-events title="HTTP/3 Events"}
 
 When any event from this document is included in a qlog trace, the
@@ -130,7 +130,7 @@ The event and data structure definitions in ths document are expressed
 in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
 extensions described in {{QLOG-MAIN}}.
 
-The following fields from {{QLOG-MAIN}} are imported and used: name, category,
+The following fields from {{QLOG-MAIN}} are imported and used: name, namespace,
 type, data, group_id, protocol_types, importance, RawInfo, and time-related
 fields.
 
@@ -142,21 +142,21 @@ implementation decision.
 
 This document describes how the core HTTP/3 protocol and selected extensions can
 be expressed in qlog using a newly defined event schema. Per the requirements in
-{{Section 8 of QLOG-MAIN}}, this document registers the `http` namespace and
-`h3` category identifiers. The URI is `urn:ietf:params:qlog:events:http#h3`.
+{{Section 8 of QLOG-MAIN}}, this document registers the `http3` namespace. The
+event schema URI is `urn:ietf:params:qlog:events:http3`.
 
 ## Draft Event Schema Identification
 {:removeinrfc="true"}
 
 Only implementations of the final, published RFC can use the events belonging to
-the category with the URI `urn:ietf:params:qlog:events:http#h3`. Until such an
+the event schema with the URI `urn:ietf:params:qlog:events:http3`. Until such an
 RFC exists, implementations MUST NOT identify themselves using this URI.
 
 Implementations of draft versions of the event schema MUST append the string
 "-" and the corresponding draft number to the URI. For example, draft 07 of this
-document is identified using the URI `urn:ietf:params:qlog:events:http#h3-07`.
+document is identified using the URI `urn:ietf:params:qlog:events:http3-07`.
 
-The category identifier itself is not affected by this requirement.
+The namespace identifier itself is not affected by this requirement.
 
 # HTTP/3 Events {#h3-ev}
 
@@ -166,19 +166,19 @@ per-event extension points via the `$$` CDDL "group socket" syntax, as also
 described in {{QLOG-MAIN}}.
 
 ~~~ cddl
-H3EventData = H3ParametersSet /
-              H3ParametersRestored /
-              H3StreamTypeSet /
-              H3PriorityUpdated /
-              H3FrameCreated /
-              H3FrameParsed /
-              H3DatagramCreated /
-              H3DatagramParsed /
-              H3PushResolved
+HTTP3EventData = HTTP3ParametersSet /
+              HTTP3ParametersRestored /
+              HTTP3StreamTypeSet /
+              HTTP3PriorityUpdated /
+              HTTP3FrameCreated /
+              HTTP3FrameParsed /
+              HTTP3DatagramCreated /
+              HTTP3DatagramParsed /
+              HTTP3PushResolved
 
-$ProtocolEventData /= H3EventData
+$ProtocolEventData /= HTTP3EventData
 ~~~
-{: #h3-events-def title="H3EventData definition and ProtocolEventData
+{: #h3-events-def title="HTTP3EventData definition and ProtocolEventData
 extension"}
 
 HTTP events are logged when a certain condition happens at the application
@@ -196,6 +196,9 @@ Furthermore, stream_data_moved events can appear before frame_parsed events
 because implementations need to read data from a stream in order to parse the
 frame header.
 
+The concrete HTTP/3 event types are further defined below, their type identifier
+is the heading name.
+
 ## parameters_set {#h3-parametersset}
 
 The `parameters_set` event contains HTTP/3 and QPACK-level settings, mostly
@@ -211,7 +214,7 @@ settings have the value "local" and received settings have the value
 "received".
 
 ~~~ cddl
-H3ParametersSet = {
+HTTP3ParametersSet = {
     ? owner: Owner
 
     ; RFC9114
@@ -232,10 +235,10 @@ H3ParametersSet = {
     ; frame before processing requests
     ? waits_for_settings: bool
 
-    * $$h3-parametersset-extension
+    * $$http3-parametersset-extension
 }
 ~~~
-{: #h3-parametersset-def title="H3ParametersSet definition"}
+{: #h3-parametersset-def title="HTTP3ParametersSet definition"}
 
 The `parameters_set` event can contain any number of unspecified fields. This
 allows for representation of reserved settings (aka GREASE) or ad-hoc support
@@ -249,7 +252,7 @@ is used to indicate which HTTP/3 settings were restored and to which values when
 utilizing 0-RTT. It has Base importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-H3ParametersRestored = {
+HTTP3ParametersRestored = {
     ; RFC9114
     ? max_field_section_size: uint64
 
@@ -263,10 +266,10 @@ H3ParametersRestored = {
     ; RFC9297 (SETTINGS_H3_DATAGRAM)
     ? h3_datagram: uint16
 
-    * $$h3-parametersrestored-extension
+    * $$http3-parametersrestored-extension
 }
 ~~~
-{: #h3-parametersrestored-def title="H3ParametersRestored definition"}
+{: #h3-parametersrestored-def title="HTTP3ParametersRestored definition"}
 
 ## stream_type_set {#h3-streamtypeset}
 
@@ -283,14 +286,14 @@ integer type. Where the type is not known, the stream_type value of "unknown"
 type can be used and the value captured in the stream_type_bytes field; a
 numerical value without variable-length integer encoding.
 
-The generic `$H3StreamType` is defined here as a CDDL "type socket" extension
+The generic `$HTTP3StreamType` is defined here as a CDDL "type socket" extension
 point. It can be extended to support additional HTTP/3 stream types.
 
 ~~~ cddl
-H3StreamTypeSet = {
+HTTP3StreamTypeSet = {
     ? owner: Owner
     stream_id: uint64
-    stream_type: $H3StreamType
+    stream_type: $HTTP3StreamType
 
     ; only when stream_type === "unknown"
     ? stream_type_bytes: uint64
@@ -298,18 +301,18 @@ H3StreamTypeSet = {
     ; only when stream_type === "push"
     ? associated_push_id: uint64
 
-    * $$h3-streamtypeset-extension
+    * $$http3-streamtypeset-extension
 }
 
-$H3StreamType /=  "request" /
-                  "control" /
-                  "push" /
-                  "reserved" /
-                  "unknown" /
-                  "qpack_encode" /
-                  "qpack_decode"
+$HTTP3StreamType /=   "request" /
+                      "control" /
+                      "push" /
+                      "reserved" /
+                      "unknown" /
+                      "qpack_encode" /
+                      "qpack_decode"
 ~~~
-{: #h3-streamtypeset-def title="H3StreamTypeSet definition"}
+{: #h3-streamtypeset-def title="HTTP3StreamTypeSet definition"}
 
 ## priority_updated {#h3-priorityupdated}
 
@@ -321,20 +324,20 @@ to local policies. The event has Base importance level; see {{Section 9.2 of
 QLOG-MAIN}}.
 
 ~~~ cddl
-H3PriorityUpdated = {
+HTTP3PriorityUpdated = {
     ; if the prioritized element is a request stream
     ? stream_id: uint64
 
     ; if the prioritized element is a push stream
     ? push_id: uint64
 
-    ? old: H3Priority
-    new: H3Priority
+    ? old: HTTP3Priority
+    new: HTTP3Priority
 
-    * $$h3-priorityupdated-extension
+    * $$http3-priorityupdated-extension
 }
 ~~~
-{: #h3-priorityupdated-def title="H3PriorityUpdated definition"}
+{: #h3-priorityupdated-def title="HTTP3PriorityUpdated definition"}
 
 ## frame_created {#h3-framecreated}
 
@@ -345,16 +348,16 @@ This event does not necessarily coincide with HTTP/3 data getting passed to the
 QUIC layer. For that, see the `stream_data_moved` event in {{QLOG-QUIC}}.
 
 ~~~ cddl
-H3FrameCreated = {
+HTTP3FrameCreated = {
     stream_id: uint64
     ? length: uint64
-    frame: $H3Frame
+    frame: $HTTP3Frame
     ? raw: RawInfo
 
-    * $$h3-framecreated-extension
+    * $$http3-framecreated-extension
 }
 ~~~
-{: #h3-framecreated-def title="H3FrameCreated definition"}
+{: #h3-framecreated-def title="HTTP3FrameCreated definition"}
 
 ## frame_parsed {#h3-frameparsed}
 
@@ -366,16 +369,16 @@ received on the QUIC layer. For that, see the `stream_data_moved` event in
 {{QLOG-QUIC}}.
 
 ~~~ cddl
-H3FrameParsed = {
+HTTP3FrameParsed = {
     stream_id: uint64
     ? length: uint64
-    frame: $H3Frame
+    frame: $HTTP3Frame
     ? raw: RawInfo
 
     * $$h3-frameparsed-extension
 }
 ~~~
-{: #h3-frameparsed-def title="H3FrameParsed definition"}
+{: #h3-frameparsed-def title="HTTP3FrameParsed definition"}
 
 
 ## datagram_created {#h3-datagramcreated}
@@ -388,15 +391,15 @@ to the QUIC layer. For that, see the `datagram_data_moved` event in
 {{QLOG-QUIC}}.
 
 ~~~ cddl
-H3DatagramCreated = {
+HTTP3DatagramCreated = {
     quarter_stream_id: uint64
-    ? datagram: $H3Datagram
+    ? datagram: $HTTP3Datagram
     ? raw: RawInfo
 
-    * $$h3-datagramcreated-extension
+    * $$http3-datagramcreated-extension
 }
 ~~~
-{: #h3-datagramcreated-def title="H3DatagramCreated definition"}
+{: #h3-datagramcreated-def title="HTTP3DatagramCreated definition"}
 
 ## datagram_parsed {#h3-datagramparsed}
 
@@ -408,15 +411,15 @@ received on the QUIC layer. For that, see the `datagram_data_moved` event in
 {{QLOG-QUIC}}.
 
 ~~~ cddl
-H3DatagramParsed = {
+HTTP3DatagramParsed = {
     quarter_stream_id: uint64
-    ? datagram: $H3Datagram
+    ? datagram: $HTTP3Datagram
     ? raw: RawInfo
 
-    * $$h3-datagramparsed-extension
+    * $$http3-datagramparsed-extension
 }
 ~~~
-{: #h3-datagramparsed-def title="H3DatagramParsed definition"}
+{: #h3-datagramparsed-def title="HTTP3DatagramParsed definition"}
 
 ## push_resolved {#h3-pushresolved}
 
@@ -427,25 +430,25 @@ additional context that can is aid debugging issues related to server push. It
 has Extra importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-H3PushResolved = {
+HTTP3PushResolved = {
     ? push_id: uint64
 
     ; in case this is logged from a place that does not have access
     ; to the push_id
     ? stream_id: uint64
-    decision: H3PushDecision
+    decision: HTTP3PushDecision
 
-    * $$h3-pushresolved-extension
+    * $$http3-pushresolved-extension
 }
 
-H3PushDecision = "claimed" /
+HTTP3PushDecision = "claimed" /
                  "abandoned"
 ~~~
-{: #h3-pushresolved-def title="H3PushResolved definition"}
+{: #h3-pushresolved-def title="HTTP3PushResolved definition"}
 
-# HTTP/3 Data Field Definitions
+# HTTP/3 Data Type Definitions
 
-The following data field definitions can be used in HTTP/3 events.
+The following data type definitions can be used in HTTP/3 events.
 
 ## Owner
 
@@ -455,84 +458,84 @@ Owner = "local" /
 ~~~
 {: #owner-def title="Owner definition"}
 
-## H3Frame
+## HTTP3Frame
 
-The generic `$H3Frame` is defined here as a CDDL "type socket" extension point.
+The generic `$HTTP3Frame` is defined here as a CDDL "type socket" extension point.
 It can be extended to support additional HTTP/3 frame types.
 
 ~~~~~~
-; The H3Frame is any key-value map (e.g., JSON object)
-$H3Frame /= {
+; The HTTP3Frame is any key-value map (e.g., JSON object)
+$HTTP3Frame /= {
     * text => any
 }
 ~~~~~~
-{: #h3-frame-def title="H3Frame type socket definition"}
+{: #h3-frame-def title="HTTP3Frame type socket definition"}
 
 The HTTP/3 frame types defined in this document are as follows:
 
 ~~~ cddl
-H3BaseFrames = H3DataFrame /
-               H3HeadersFrame /
-               H3CancelPushFrame /
-               H3SettingsFrame /
-               H3PushPromiseFrame /
-               H3GoawayFrame /
-               H3MaxPushIDFrame /
-               H3ReservedFrame /
-               H3UnknownFrame
+HTTP3BaseFrames = HTTP3DataFrame /
+                  HTTP3HeadersFrame /
+                  HTTP3CancelPushFrame /
+                  HTTP3SettingsFrame /
+                  HTTP3PushPromiseFrame /
+                  HTTP3GoawayFrame /
+                  HTTP3MaxPushIDFrame /
+                  HTTP3ReservedFrame /
+                  HTTP3UnknownFrame
 
-$H3Frame /= H3BaseFrames
+$HTTP3Frame /= HTTP3BaseFrames
 ~~~
-{: #h3baseframe-def title="H3BaseFrames definition"}
+{: #h3baseframe-def title="HTTP3BaseFrames definition"}
 
-## H3Datagram
+## HTTP3Datagram
 
-The generic `$H3Datagram` is defined here as a CDDL "type socket" extension
+The generic `$HTTP3Datagram` is defined here as a CDDL "type socket" extension
 point. It can be extended to support additional HTTP/3 datagram types. This
 document intentionally does not define any specific qlog schemas for specific
 HTTP/3 Datagram types.
 
 ~~~~~~
-; The H3Datagram is any key-value map (e.g., JSON object)
-$H3Datagram /= {
+; The HTTP3Datagram is any key-value map (e.g., JSON object)
+$HTTP3Datagram /= {
     * text => any
 }
 ~~~~~~
-{: #h3-datagram-def title="H3Datagram type socket definition"}
+{: #h3-datagram-def title="HTTP3Datagram type socket definition"}
 
-### H3DataFrame
+### HTTP3DataFrame
 
 ~~~ cddl
-H3DataFrame = {
+HTTP3DataFrame = {
     frame_type: "data"
     ? raw: RawInfo
 }
 ~~~
-{: #h3dataframe-def title="H3DataFrame definition"}
+{: #h3dataframe-def title="HTTP3DataFrame definition"}
 
-### H3HeadersFrame
+### HTTP3HeadersFrame
 
 The payload of an HTTP/3 HEADERS frame is the QPACK-encoding of an HTTP field
-section; see {{Section 7.2.2 of RFC9114}}. `H3HeaderFrame`, in contrast,
+section; see {{Section 7.2.2 of RFC9114}}. `HTTP3HeaderFrame`, in contrast,
 contains the HTTP field section without QPACK encoding.
 
 ~~~ cddl
-H3HTTPField = {
+HTTP3HTTPField = {
     ? name: text
     ? name_bytes: hexstring
     ? value: text
     ? value_bytes: hexstring
 }
 ~~~
-{: #h3field-def title="H3HTTPField definition"}
+{: #h3field-def title="HTTP3HTTPField definition"}
 
 ~~~ cddl
-H3HeadersFrame = {
+HTTP3HeadersFrame = {
     frame_type: "headers"
-    headers: [* H3HTTPField]
+    headers: [* HTTP3HTTPField]
 }
 ~~~
-{: #h3-headersframe-def title="H3HeadersFrame definition"}
+{: #h3-headersframe-def title="HTTP3HeadersFrame definition"}
 
 For example, the HTTP field section
 
@@ -565,30 +568,30 @@ headers: [
   }
 ]
 ~~~
-{: #h3-headersframe-ex title="H3HeadersFrame example"}
+{: #h3-headersframe-ex title="HTTP3HeadersFrame example"}
 
 {{Section 4.2 of RFC9114}} and {{Section 5.1 of RFC9110}} define rules for the
 characters used in HTTP field sections names and values. Characters outside the
-range are invalid and result in the message being treated as malformed. It can however be useful to also log these invalid HTTP fields.
-Characters in the
+range are invalid and result in the message being treated as malformed. It can
+however be useful to also log these invalid HTTP fields. Characters in the
 allowed range can be safely logged by the text type used in the `name` and
-`value` fields of `H3HTTPField`. Characters outside the range are unsafe for the
+`value` fields of `HTTP3HTTPField`. Characters outside the range are unsafe for the
 text type and need to be logged using the `name_bytes` and `value_bytes` field.
-An instance of `H3HTTPField` MUST include either the `name` or `name_bytes`
-field and MAY include both. An `H3HTTPField` MAY include a `value` or
+An instance of `HTTP3HTTPField` MUST include either the `name` or `name_bytes`
+field and MAY include both. An `HTTP3HTTPField` MAY include a `value` or
 `value_bytes` field or neither.
 
-### H3CancelPushFrame
+### HTTP3CancelPushFrame
 
 ~~~ cddl
-H3CancelPushFrame = {
+HTTP3CancelPushFrame = {
     frame_type: "cancel_push"
     push_id: uint64
 }
 ~~~
-{: #h3-cancelpushframe-def title="H3CancelPushFrame definition"}
+{: #h3-cancelpushframe-def title="HTTP3CancelPushFrame definition"}
 
-### H3SettingsFrame
+### HTTP3SettingsFrame
 
 The settings field can contain zero or more entries. Each setting has a name
 field, which corresponds to Setting Name as defined (or as would be defined if
@@ -600,20 +603,20 @@ Instead, the name value of "unknown" can be used and the value captured in the
 `name_bytes` field; a numerical value without variable-length integer encoding.
 
 ~~~ cddl
-H3SettingsFrame = {
+HTTP3SettingsFrame = {
     frame_type: "settings"
-    settings: [* H3Setting]
+    settings: [* HTTP3Setting]
 }
 
-H3Setting = {
-    ? name: $H3SettingsName
+HTTP3Setting = {
+    ? name: $HTTP3SettingsName
     ; only when name === "unknown"
     ? name_bytes: uint64
 
     value: uint64
 }
 
-$H3SettingsName /= "settings_qpack_max_table_capacity" /
+$HTTP3SettingsName /= "settings_qpack_max_table_capacity" /
                    "settings_max_field_section_size" /
                    "settings_qpack_blocked_streams" /
                    "settings_enable_connect_protocol" /
@@ -621,23 +624,23 @@ $H3SettingsName /= "settings_qpack_max_table_capacity" /
                    "reserved" /
                    "unknown"
 ~~~
-{: #h3settingsframe-def title="H3SettingsFrame definition"}
+{: #h3settingsframe-def title="HTTP3SettingsFrame definition"}
 
-### H3PushPromiseFrame
+### HTTP3PushPromiseFrame
 
 ~~~ cddl
-H3PushPromiseFrame = {
+HTTP3PushPromiseFrame = {
     frame_type: "push_promise"
     push_id: uint64
-    headers: [* H3HTTPField]
+    headers: [* HTTP3HTTPField]
 }
 ~~~
-{: #h3pushpromiseframe-def title="H3PushPromiseFrame definition"}
+{: #h3pushpromiseframe-def title="HTTP3PushPromiseFrame definition"}
 
-### H3GoAwayFrame
+### HTTP3GoAwayFrame
 
 ~~~ cddl
-H3GoawayFrame = {
+HTTP3GoawayFrame = {
     frame_type: "goaway"
 
     ; Either stream_id or push_id.
@@ -645,24 +648,24 @@ H3GoawayFrame = {
     id: uint64
 }
 ~~~
-{: #h3goawayframe-def title="H3GoawayFrame definition"}
+{: #h3goawayframe-def title="HTTP3GoawayFrame definition"}
 
-### H3MaxPushIDFrame
+### HTTP3MaxPushIDFrame
 
 ~~~ cddl
-H3MaxPushIDFrame = {
+HTTP3MaxPushIDFrame = {
     frame_type: "max_push_id"
     push_id: uint64
 }
 ~~~
-{: #h3maxpushidframe-def title="H3MaxPushIDFrame definition"}
+{: #h3maxpushidframe-def title="HTTP3MaxPushIDFrame definition"}
 
-### H3PriorityUpdateFrame
+### HTTP3PriorityUpdateFrame
 
 The PRIORITY_UPDATE frame is defined in {{!RFC9218}}.
 
 ~~~ cddl
-H3PriorityUpdateFrame = {
+HTTP3PriorityUpdateFrame = {
     frame_type: "priority_update"
 
     ; if the prioritized element is a request stream
@@ -671,43 +674,43 @@ H3PriorityUpdateFrame = {
     ; if the prioritized element is a push stream
     ? push_id: uint64
 
-    priority_field_value: H3Priority
+    priority_field_value: HTTP3Priority
 }
 
 ; The priority value in ASCII text, encoded using Structured Fields
 ; Example: u=5, i
-H3Priority = text
+HTTP3Priority = text
 ~~~
-{: #h3priorityupdateframe-def title="h3priorityupdateframe definition"}
+{: #h3priorityupdateframe-def title="HTTP3PriorityUpdateFrame definition"}
 
-### H3ReservedFrame
+### HTTP3ReservedFrame
 
 ~~~ cddl
-H3ReservedFrame = {
+HTTP3ReservedFrame = {
     frame_type: "reserved"
     ? length: uint64
 }
 ~~~
-{: #h3reservedframe-def title="H3ReservedFrame definition"}
+{: #h3reservedframe-def title="HTTP3ReservedFrame definition"}
 
-### H3UnknownFrame
+### HTTP3UnknownFrame
 
 The frame_type_bytes field is the numerical value without variable-length
 integer encoding.
 
 ~~~ cddl
-H3UnknownFrame = {
+HTTP3UnknownFrame = {
     frame_type: "unknown"
     frame_type_bytes: uint64
     ? raw: RawInfo
 }
 ~~~
-{: #h3unknownframe-def title="UnknownFrame definition"}
+{: #h3unknownframe-def title="HTTP3UnknownFrame definition"}
 
-### H3ApplicationError
+### HTTP3ApplicationError
 
 ~~~ cddl
-H3ApplicationError = "http_no_error" /
+HTTP3ApplicationError = "http_no_error" /
                        "http_general_protocol_error" /
                        "http_internal_error" /
                        "http_stream_creation_error" /
@@ -725,15 +728,15 @@ H3ApplicationError = "http_no_error" /
                        "http_connect_error" /
                        "http_version_fallback"
 ~~~
-{: #h3-applicationerror-def title="H3ApplicationError definition"}
+{: #h3-applicationerror-def title="HTTP3ApplicationError definition"}
 
-The H3ApplicationError extends the general $ApplicationError
+The HTTP3ApplicationError extends the general $ApplicationError
 definition in the qlog QUIC document, see {{QLOG-QUIC}}.
 
 ~~~ cddl
 ; ensure HTTP errors are properly validated in QUIC events as well
 ; e.g., QUIC's ConnectionClose Frame
-$ApplicationError /= H3ApplicationError
+$ApplicationError /= HTTP3ApplicationError
 ~~~
 
 # Security and Privacy Considerations
@@ -743,10 +746,16 @@ document as well.
 
 # IANA Considerations
 
-This document registers a new entry in the "qlog event category URIs" registry.
+This document registers a new entry in the "qlog event schema URIs" registry.
 
-Event Category URI:
-: urn:ietf:params:qlog:events:http#h3
+Event schema URI:
+: urn:ietf:params:qlog:events:http3
+
+Namespace
+: http3
+
+Event Types
+: parameters_set,parameters_restored,stream_type_set,priority_updated,frame_created,frame_parsed,datagram_created,datagram_parsed,push_resolved
 
 Description:
 : Event definitions related to the HTTP/3 application protocol.

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -930,11 +930,15 @@ fields are "time" and "data", who are divergent by nature.
 
 # Concrete Event Types and Event Schema {#event-types-and-schema}
 
-Concrete event types (for example: packet_sent), as well as related data types
-(for example: QUICPacketHeader), are grouped in event namespaces (for example:
-quic) which in turn are defined in one or multiple event schemas (for example:
-urn:ietf:params:qlog:events:quic and
-urn:ietf:params:qlog:events:quic#extension1).
+Concrete event types, as well as related data types, are grouped in event
+namespaces which in turn are defined in one or multiple event schemas.
+
+As an example, the `QUICPacketSent` and `QUICPacketHeader` event and data types
+would be part of the `quic` namespace, which is defined in an event schema with
+URI `urn:ietf:params:qlog:events:quic`. A later extension that adds a new QUIC
+frame `QUICNewFrame` would also be part of the `quic` namespace, but defined in
+a new event schema with URI
+`urn:ietf:params:qlog:events:quic#new-frame-extension`.
 
 Concrete event types MUST belong to a single event namespace and MUST have a
 registered non-empty identifier of type `text`.
@@ -1011,7 +1015,7 @@ Event schema that define a new namespace SHOULD use a URN of the form
 `urn:ietf:params:qlog:events:<namespace identifier>`, where `<namespace
 identifier>` is globally unique. For example, this document defines two event
 schemas ({{generic-event-schema}}) for two namespaces: `loglevel` and `sim`.
-Other examples of event schema define the `quic` {{QLOG-QUIC}} and `http`
+Other examples of event schema define the `quic` {{QLOG-QUIC}} and `http3`
 {{QLOG-H3}} namespaces.
 
 Event schema that extend an existing namespace SHOULD use a URN of the form

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -106,7 +106,7 @@ tooling. This document describes key concepts of qlog: formats, files, traces,
 events, and extension points. This definition includes the high-level log file
 schemas, and generic event schemas. Requirements and guidelines for creating
 protocol-specific event schemas are also presented. Accompanying documents
-define event schema for QUIC ({{QLOG-QUIC}}) and HTTP/3 ({{QLOG-H3}}).
+define event schemas for QUIC ({{QLOG-QUIC}}) and HTTP/3 ({{QLOG-H3}}).
 
 The goal of qlog is to provide amenities and default characteristics that each
 logging file should contain (or should be able to contain), such that generic
@@ -232,20 +232,10 @@ Events are logged at a time instant and convey specific details of the logging
 use case. For example, a network packet being sent or received. This document
 declares an abstract Event class ({{abstract-event}}) containing common fields,
 which all concrete events derive from. Concrete events are defined by event
-schemas that declare a namespace, consisting of one or more categories,
-containing one or more related event types. For example, this document defines
-the generic event schema structured as:
-
-* `gen` namespace
-  * `loglevel` category
-    * `error` event type
-    * `warning` event type
-    * `info` event type
-    * `debug` event type
-    * `verbose` event type
-  * `sim` category
-    * `scenario` event type
-    * `marker` event type
+schemas that declare or extend a namespace, which contains one or more related
+event types or their extensions. For example, this document defines two event
+schemas for two generic event namespaces `loglevel` and `simulation` (see
+{{generic-event-schema}}).
 
 # Abstract LogFile Class {#abstract-logfile}
 
@@ -282,7 +272,7 @@ The optional "title" and "description" fields provide additional free-text
 information about the file.
 
 The required "event_schemas" field contains event schema URIs that identify
-concrete event categories and their associated types recorded in a log.
+concrete event namespaces and their associated types recorded in a log.
 Requirements and guidelines are defined in {{event-types-and-schema}}.
 
 ## Concrete Log File Schema URIs {#schema-uri}
@@ -315,16 +305,7 @@ satisfies the requirements in this section. A request to register a private or
 non-standard log file schema URI using a URN of the form
 `urn:ietf:params:qlog:file:<schema-identifier>` MUST be rejected.
 
-Registration requests should use the following template:
-
-Log File Schema URI:
-: \[the log file schema identifier\]
-
-Description:
-: \[a description of the log file schema\]
-
-Reference:
-: \[to a specification defining the log file schema\]
+Registration requests should use the template defined in {{iana}}.
 
 # QlogFile schema {#qlog-file-schema}
 
@@ -949,103 +930,114 @@ fields are "time" and "data", who are divergent by nature.
 
 # Concrete Event Types and Event Schema {#event-types-and-schema}
 
-Concrete event types belong to event categories, both contained in event schema.
+Concrete event types (for example: packet_sent), as well as related data types
+(for example: QUICPacketHeader), are grouped in event namespaces (for example:
+quic) which in turn are defined in one or multiple event schemas (for example:
+urn:ietf:params:qlog:events:quic and
+urn:ietf:params:qlog:events:quic#extension1).
 
-A single event schema can either define a new namespace, or extend an existing
-namespace with new categories. New namespaces MUST be registered using a
-non-empty namespace identifier text identifier using only characters in the
-unreserved range; see {{Section 2.3 of RFC3986}}. Namespace are mutable and MAY
-be extended with categories.
+Concrete event types MUST belong to a single event namespace and MUST have a
+registered non-empty identifier of type `text`.
 
-Event categories MUST belong to a single event namespace. They MUST have a
-registered non-empty globally-unique text identifier using only characters in
-the URI unreserved range; see {{Section 2.3 of RFC3986}}. They MUST have a
-single URI {{RFC3986}} that MUST be absolute. The URI MUST include the namespace
-identifier. The URI MUST include the category identifer using a fragment
-identifier (characters after a "#" in the URI). Event categories are immutable
-and MUST NOT be extended with events. Registration guidance and requirement for
-category URIs are provided in {{event-schema-reg}}.
+New namespaces MUST have a registered non-empty globally-unique text identifier
+using only characters in the URI unreserved range; see {{Section 2.3 of
+RFC3986}}. Namespaces are mutable and MAY be extended with new events.
 
-Concrete event types MUST belong to a single event category and MUST have a
-non-empty name of type `text`.
+The value of a qlog event `name` field MUST be the concatenation of namespace
+identifier, colon (':'), and event type identifier (for example:
+quic:packet_sent). The resulting concatenation MUST be globally unique, so log
+files can contain events from multiple schemas without the risk of name
+collisions.
 
-The value of a qlog event `name` field MUST be the concatenation of category
-identifier, colon (':'), and event type identifier. By virtue of the identifier
-requirements described above, event names are globally-unique. Thus, log files
-can contain events from multiple schemas without the risk of name collisions.
+A single event schema can contain exactly one of the below:
+* A definition for a new event namespace
+* An extension of an existing namespace (adding new events/data types and/or
+  extending existing events/data types within the namespace with new fields)
 
-Implementations that might record concrete event types belonging to a category
-in an event schema SHOULD list all category identifiers in use. This is achieved
-by including the appropriate URIs in the `event_schemas` field of the abstract
-LogFile class ({{abstract-logfile}}). The `event_schemas` is a hint to tools
-about the possible event categories (and event types contained therein) that a
-qlog file might contain. The file MAY contain event types that do not belong to
-a listed category identifier. Inversely, not all event types associated with a
-category listed in `event_schemas` are guaranteed to be logged in a qlog file.
-Tools MUST NOT treat either of these as an error; see {{tooling}}.
+A single document can define multiple event schemas (for example see
+{{generic-event-schema}}).
 
-In the following hypothetical example, a qlog file contains events belonging to
-two categories in the generic event schema defined in this document
-({{generic-event-schema}}), to three categories in an event schema named `rick`
-specified in a hypothetical RFC, and to three more categories from a private
-event schema named pickle. The standardized category URIs use a URN format, the
-private categories use a URI with domain name.
+Event schema MUST have a single URI {{RFC3986}} that MUST be absolute. The URI
+MUST include the namespace identifier. Event schema that extend an existing
+namespace MUST furthermore include a non-empty globally-unique "extension"
+identifier using a URI fragment (characters after a "#" in the URI) using only
+characters in the URI unreserved range; see {{Section 2.3 of RFC3986}}.
+Registration guidance and requirement for event schema URIs are provided in
+{{event-schema-reg}}. Event schemas by themselves are immutable and MUST NOT be
+extended.
+
+Implementations that record concrete event types SHOULD list all event schema in
+use. This is achieved by including the appropriate URIs in the `event_schemas`
+field of the abstract LogFile class ({{abstract-logfile}}). The `event_schemas`
+is a hint to tools about the possible event namespaces, their extensions, and
+the event types/data types contained therein, that a qlog file might contain.
+The file MAY contain event types that do not belong to a listed event schema.
+Inversely, not all event types associated with an event schema listed in
+`event_schemas` are guaranteed to be logged in a qlog file. Tools MUST NOT treat
+either of these as an error; see {{tooling}}.
+
+In the following hypothetical example, a qlog file contains events belonging to:
+* The two event namespaces defined by event schemas in this document
+({{generic-event-schema}}).
+* Events in a namespace named `rick` specified in a hypothetical RFC
+* Extentions to the `rick` namespace defined in two separate new event schemas
+  (with URI extension identifiers `astley` and `moranis`)
+* Events from three private event schemas, detailing definitions for and
+  extensions to two namespaces (`pickle` and `cucumber`)
+
+The standardized schema URIs use a URN format, the private schemas use a URI
+with domain name.
 
 ~~~
 "event_schemas": [
-  "urn:ietf:params:qlog:events:gen#loglevel",
-  "urn:ietf:params:qlog:events:gen#sim",
-  "urn:ietf:params:qlog:events:rick#roll",
+  "urn:ietf:params:qlog:events:loglevel",
+  "urn:ietf:params:qlog:events:simulation",
+  "urn:ietf:params:qlog:events:rick",
   "urn:ietf:params:qlog:events:rick#astley",
   "urn:ietf:params:qlog:events:rick#moranis",
-  "https://example.com/032024/pickle.html#pepper",
+  "https://example.com/032024/pickle.html",
   "https://example.com/032024/pickle.html#lilly",
-  "https://example.com/032024/pickle.html#rick"
+  "https://example.com/032025/cucumber.html"
 ]
 ~~~
-{: #event-categories title="Example event_categories serialization"}
+{: #event-schemas title="Example event_schemas serialization"}
 
-## Event Schema and Event Category URIs {#event-schema-reg}
+## Event Schema URIs {#event-schema-reg}
 
-Event schema defined by RFCs MUST register all categories in the "qlog event
-category URIs" registry and SHOULD use a URN of the form
-`urn:ietf:params:qlog:events:<namespace identifier>#<category identifier>`,
-where `<category identifier>` is globally unique. For example, this document
-defines the generic event schema ({{generic-event-schema}}) that uses the `gen`
-namespace containing the `loglevel` and `sim` categories. Other examples of
-event schema define the `quic` {{QLOG-QUIC}} and `http` {{QLOG-H3}} namespaces.
+Event schema defined by RFCs MUST register all namespaces and concrete event
+types they contain in the "qlog event schema URIs" registry.
 
-Private or non-standard event categories MAY be registered in the "qlog event
-category URIs" registry but MUST NOT use a URN of the form
-`urn:ietf:params:qlog:events:<namespace identifier>#<category identifier>`. URIs
+Event schema that define a new namespace SHOULD use a URN of the form
+`urn:ietf:params:qlog:events:<namespace identifier>`, where `<namespace
+identifier>` is globally unique. For example, this document defines two event
+schemas ({{generic-event-schema}}) for two namespaces: `loglevel` and `sim`.
+Other examples of event schema define the `quic` {{QLOG-QUIC}} and `http`
+{{QLOG-H3}} namespaces.
+
+Event schema that extend an existing namespace SHOULD use a URN of the form
+`urn:ietf:params:qlog:events:<namespace identifier>#<extension identifier>`,
+where the combination of `<namespace identifier>` and `<extension identifier>`
+is globally unique.
+
+Private or non-standard event schemas MAY be registered in the "qlog event
+schema URIs" registry but MUST NOT use a URN of the forms outlined above. URIs
 that contain a domain name SHOULD also contain a month-date in the form mmyyyy.
-For example,
-"https://example.org/072024/customeventschema#globallyuniquecategory". The
-definition of the category and assignment of the URI MUST have been authorized
-by the owner of the domain name on or very close to that date. This avoids
-problems when domain names change ownership. The URI does not need to be
-dereferencable, allowing for confidential use or to cover the case where the log
-file schema continues to be used after the organization that defined them ceases
-to exist.
+For example, "https://example.org/072024/customeventschema#customextension". The
+definition of the event schema and assignment of the URI MUST have been
+authorized by the owner of the domain name on or very close to that date. This
+avoids problems when domain names change ownership. The URI does not need to be
+dereferencable, allowing for confidential use or to cover the case where the
+event schema continues to be used after the organization that defined them
+ceases to exist.
 
-The "qlog event category URIs" registry operates under the Expert Review policy,
+The "qlog event schema URIs" registry operates under the Expert Review policy,
 per {{Section 4.5 of !RFC8126}}.  When reviewing requests, the expert MUST check
 that the URI is appropriate to the event schema and satisfies the requirements
 in {{event-types-and-schema}} and this section. A request to register a private
-or non-standard category URI using a URN of the form
-`urn:ietf:params:qlog:events:<namespace identifier>#<category identifier` MUST be
-rejected.
+or non-standard schema URI using a URN of the forms reserved for schemas defined
+by an RFC above MUST be rejected.
 
-Registration requests should use the following template:
-
-Event Category URI:
-: \[the event category identifier\]
-
-Description:
-: \[a description of the event category\]
-
-Reference:
-: \[to a specification defining the event schema defining the event category\]
+Registration requests should use the template defined in {{iana}}.
 
 ## Extending the Data Field {#data-field}
 
@@ -1059,33 +1051,33 @@ In order to keep qlog fully extensible, two separate CDDL extension points
 
 Firstly, to allow existing data field definitions to be extended (for example by
 adding an additional field needed for a new protocol feature), a CDDL "group
-socket" is used. This takes the form of a subfield with a name of
-`* $$CATEGORY-NAME-extension`. This field acts as a placeholder that can later be
-replaced with newly defined fields by assigning them to the socket with the
-`//=` operator. Multiple extensions can be assigned to the same group socket. An
-example is shown in {{groupsocket-extension-example}}.
+socket" is used. This takes the form of a subfield with a name of `*
+$$NAMESPACE-EVENTTYPE-extension`. This field acts as a placeholder that can
+later be replaced with newly defined fields by assigning them to the socket with
+the `//=` operator. Multiple extensions can be assigned to the same group
+socket. An example is shown in {{groupsocket-extension-example}}.
 
 ~~~~~~~~
-; original definition in document A
-MyCategoryEventX = {
+; original definition in event schema A
+MyNSEventX = {
     field_a: uint8
 
-    * $$mycategory-eventx-extension
+    * $$myns-eventx-extension
 }
 
-; later extension of EventX in document B
-$$mycategory-eventx-extension //= (
+; later extension of EventX in event schema B
+$$myns-eventx-extension //= (
   ? additional_field_b: bool
 )
 
-; another extension of EventX in document C
-$$mycategory-eventx-extension //= (
+; another extension of EventX in event schema C
+$$myns-eventx-extension //= (
   ? additional_field_c: text
 )
 
-; if document A, B and C are then used in conjunction,
-; the combined MyCategoryEventX CDDL is equivalent to this:
-MyCategoryEventX = {
+; if schemas A, B and C are then used in conjunction,
+; the combined MyNSEventX CDDL is equivalent to this:
+MyNSEventX = {
     field_a: uint8
 
     ? additional_field_b: bool
@@ -1107,71 +1099,67 @@ key-value map type can be assigned to `$ProtocolEventData` (the only common
 {{protocoleventdata-def}}.
 
 ~~~~~~~~
-; We define two separate events in a single document
-MyCategoryEvent1 /= {
+; We define two new concrete events in a new event schema
+MyNSEvent1 /= {
     field_1: uint8
 
     ? trigger: text
 
-    * $$mycategory-event1-extension
+    * $$myns-event1-extension
 }
 
-MyCategoryEvent2 /= {
+MyNSEvent2 /= {
     field_2: bool
 
     ? trigger: text
 
-    * $$mycategory-event2-extension
+    * $$myns-event2-extension
 }
 
 ; the events are both merged with the existing
 ; $ProtocolEventData type enum
-$ProtocolEventData /= MyCategoryEvent1 / MyCategoryEvent2
+$ProtocolEventData /= MyNSEvent1 / MyNSEvent2
 
 ; the "data" field of a qlog event can now also be of type
-; MyCategoryEvent1 and MyCategoryEvent2
+; MyNSEvent1 and MyNSEvent2
 ~~~~~~~~
 {: #protocoleventdata-def title="ProtocolEventData extension"}
 
-Documents defining new qlog events MUST properly extend `$ProtocolEventData`
+Event schema defining new qlog events MUST properly extend `$ProtocolEventData`
 when defining data fields to enable automated validation of aggregated qlog
-schemas. Furthermore, they SHOULD properly add a `* $$CATEGORY-NAME-extension`
+schemas. Furthermore, they SHOULD add a `* $$NAMESPACE-EVENTTYPE-extension`
 extension field to newly defined event data to allow the new events to be
-properly extended by other documents.
+properly extended by other event schema.
 
 A combined but purely illustrative example of the use of both extension points
 for a conceptual QUIC "packet_sent" event is shown in {{data-ex}}:
 
 ~~~~~~~~
-; defined in the main QUIC event document
-TransportPacketSent = {
+; defined in the main QUIC event schema
+QUICPacketSent = {
     ? packet_size: uint16
-    header: PacketHeader
-    ? frames:[* QuicFrame]
-    ? trigger: "pto_probe" /
-               "retransmit_timeout" /
-               "bandwidth_probe"
+    header: QUICPacketHeader
+    ? frames:[* QUICFrame]
 
-    * $$transport-packetsent-extension
+    * $$quic-packetsent-extension
 }
 
 ; Add the event to the global list of recognized qlog events
-$ProtocolEventData /= TransportPacketSent
+$ProtocolEventData /= QUICPacketSent
 
-; Defined in a separate document that describes a
+; Defined in a separate event schema that describes a
 ; theoretical QUIC protocol extension
-$$transport-packetsent-extension //= (
+$$quic-packetsent-extension //= (
   ? additional_field: bool
 )
 
-; If both documents are utilized at the same time,
+; If both schemas are utilized at the same time,
 ; the following JSON serialization would pass an automated
 ; CDDL schema validation check:
 
 {
   "time": 123456,
-  "category": "transport",
-  "name": "packet_sent",
+  "name": "quic:packet_sent",
   "data": {
       "packet_size": 1280,
       "header": {
@@ -1282,7 +1270,7 @@ guidance on which to use in specific situations.
 ## Tooling Expectations
 
 qlog is an extensible format and it is expected that new event schema will
-emerge that define new categories, event types, event fields (e.g., a field
+emerge that define new namespaces, event types, event fields (e.g., a field
 indicating an event's privacy properties), as well as values for the "trigger"
 property within the "data" field, or other member fields of the "data" field, as
 they see fit.
@@ -1315,21 +1303,21 @@ additional events is typically avoided. Exceptions have been made for common
 events that benefit from being easily identifiable or individually logged (for
 example `packets_acked`).
 
-# The Generic Event Schema {#generic-event-schema}
+# The Generic Event Schemas {#generic-event-schema}
 
-The generic event schema defines categories and event types that are common
-across protocols, applications, and use cases. The schema namespace identifier
-is "gen".
+The two following generic event schemas define two namespaces and several
+concrete event types that are common across protocols, applications, and use
+cases.
 
-## Log Level Events {#loglevel-events}
+## Loglevel events {#loglevel-events}
 
 In typical logging setups, users utilize a discrete number of well-defined
-logging categories, levels or severities to log freeform (string) data. The log
-level event category replicates this approach to allow implementations to fully
-replace their existing text-based logging by qlog. This is done by providing
-events to log generic strings for the typical well-known logging levels (error,
-warning, info, debug, verbose). The category identifier is "loglevel". The
-category URI is is `urn:ietf:params:qlog:events:gen#loglevel`.
+logging categories, levels or severities to log freeform (string) data. The
+loglevel event namespace replicates this approach to allow implementations to
+fully replace their existing text-based logging by qlog. This is done by
+providing events to log generic strings for the typical well-known logging
+levels (error, warning, info, debug, verbose). The namespace identifier is
+"loglevel". The event schema URI is `urn:ietf:params:qlog:events:loglevel`.
 
 ~~~ cddl
 LogLevelEventData = LogLevelError /
@@ -1426,9 +1414,9 @@ interoperability or benchmarking tests, in which the test situations can change
 over time. For example, the network bandwidth or latency can vary during the
 test, or the network can be fully disable for a short time. In these setups, it
 is useful to know when exactly these conditions are triggered, to allow for
-proper correlation with other events. This category defines event types to allow
-logging of such simulation metadata and its identifier is "sim". The category
-URI is `urn:ietf:params:qlog:events:gen#sim`.
+proper correlation with other events. This namespace defines event types to
+allow logging of such simulation metadata and its identifier is "simulation".
+The event schema URI is `urn:ietf:params:qlog:events:simulation`.
 
 ~~~ cddl
 SimulationEventData = SimulationScenario /
@@ -1781,14 +1769,15 @@ tagged with the "group_id" field with values "abcde" and "12345".
 
 # Tooling requirements {#tooling}
 
-Tools ingestion qlog MUST indicate which qlog version(s), qlog format(s),
-compression methods and potentially other input file formats (for example .pcap)
-they support. Tools SHOULD at least support .qlog files in the default JSON format
-({{format-json}}). Additionally, they SHOULD indicate exactly which values for and
-properties of the name (category and type) and data fields they look for to
-execute their logic. Tools SHOULD perform a (high-level) check if an input qlog
-file adheres to the expected qlog schema. If a tool determines a qlog file does
-not contain enough supported information to correctly execute the tool's logic, it
+Tools ingestion qlog MUST indicate which qlog version(s), qlog format(s), qlog
+file and event schema(s), compression methods and potentially other input file
+formats (for example .pcap) they support. Tools SHOULD at least support .qlog
+files in the default JSON format ({{format-json}}). Additionally, they SHOULD
+indicate exactly which values for and properties of the name
+(namespace:event_type) and data fields they look for to execute their logic.
+Tools SHOULD perform a (high-level) check if an input qlog file adheres to the
+expected qlog file and event schemas. If a tool determines a qlog file does not
+contain enough supported information to correctly execute the tool's logic, it
 SHOULD generate a clear error message to this effect.
 
 Tools MUST NOT produce breaking errors for any field names and/or values in the
@@ -1931,20 +1920,77 @@ IANA Registry Reference:
 
 IANA is requested to create the "qlog log file schema URIs" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
-log file schema. It has the following format:
+log file schema. It has the following format/template:
+
+Log File Schema URI:
+: \[the log file schema identifier\]
+
+Description:
+: \[a description of the log file schema\]
+
+Reference:
+: \[to a specification defining the log file schema\]
+
+
+This document furthermore adds the following two new entries to the "qlog log
+file schema URIs" registry:
 
 | Log File Schema URI | Description | Reference |
 | urn:ietf:params:qlog:file:contained | Concrete log file schema that can contain several traces from multiple vantage points. | {{qlog-file-schema}} |
 | urn:ietf:params:qlog:file:sequential | Concrete log file schema containing a single trace, optimized for seqential read and write access. | {{qlog-file-seq-schema}} |
 
-IANA is requested to create the "qlog event category URIs" registry
+IANA is requested to create the "qlog event schema URIs" registry
 at [](https://www.iana.org/assignments/qlog) for the purpose of registering
-event categories. It has the following format:
+event schema. It has the following format/template:
 
-| Event Category URI | Description | Reference |
-| urn:ietf:params:qlog:events:gen#loglevel | Well-known logging levels for free-form text. | {{loglevel-events}} |
-| urn:ietf:params:qlog:events:gen#sim | Events for simulation testing. | {{sim-events}} |
+Event schema URI:
+: \[the event schema identifier\]
 
+Namespace:
+: \[the identifier of the namespace that this event schema either defines or extends\]
+
+Event Types:
+: \[a comma-separated list of concrete event types defined in the event schema\]
+
+Description:
+: \[a description of the event schema\]
+
+Reference:
+: \[to a specification defining the event schema definition\]
+
+This document furthermore adds the following two new entries to the "qlog event
+schema URIs" registry:
+
+Event schema URI:
+: urn:ietf:params:qlog:events:loglevel
+
+Namespace
+: loglevel
+
+Event Types
+: error,warning,info,debug,verbose
+
+Description:
+: Well-known logging levels for free-form text.
+
+Reference:
+: {{loglevel-events}}
+
+
+Event schema URI:
+: urn:ietf:params:qlog:events:simulation
+
+Namespace
+: simulation
+
+Event Types
+: scenario,marker
+
+Description:
+: Events for simulation testing.
+
+Reference:
+: {{sim-events}}
 
 --- back
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -71,14 +71,13 @@ containing concrete events for the core QUIC protocol (see
 {{!QUIC-TLS=RFC9001}}) and some of its extensions (see
 {{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
 
-The event schema namespace `quic` is defined, containing the categories:
-`connectivity` ({{conn-ev}}), `security` ({{sec-ev}}), `quic` {{quic-ev}}, and
-`recovery` {{rec-ev}}. Across these categories multiple events derive from the
-qlog abstract Event class ({{Section 7 of QLOG-MAIN}}), each extending the
-"data" field and defining their "name" field values and semantics. Some data
-fields use complex datastructures. These are represented as enums or re-usable
-definitions, which are grouped together on the bottom of this document for
-clarity.
+
+The event namespace with identifier `http3` is defined; see {{schema-def}}. In
+this namespace multiple events derive from the qlog abstract Event class
+({{Section 7 of QLOG-MAIN}}), each extending the "data" field and defining their
+"name" field values and semantics. Some event data fields use complex data
+types. These are represented as enums or re-usable definitions, which are
+grouped together on the bottom of this document for clarity.
 
 When any event from this document is included in a qlog trace, the
 `protocol_types` qlog array field MUST contain an entry with the value "QUIC":
@@ -134,7 +133,7 @@ The event and data structure definitions in ths document are expressed
 in the Concise Data Definition Language {{!CDDL=RFC8610}} and its
 extensions described in {{QLOG-MAIN}}.
 
-The following fields from {{QLOG-MAIN}} are imported and used: name, category,
+The following fields from {{QLOG-MAIN}} are imported and used: name, namespace,
 type, data, group_id, protocol_types, importance, RawInfo, and time-related
 fields.
 
@@ -146,29 +145,21 @@ implementation decision.
 
 This document describes how the core QUIC protocol and selected extensions can
 be expressed in qlog using a newly defined event schema. Per the requirements in
-{{Section 8 of QLOG-MAIN}}, this document registers the `quic` namespace and the
-following category identifiers and URIs.
-
-* `connectivity` - `urn:ietf:params:qlog:events:quic#connectivity`
-* `security` - `urn:ietf:params:qlog:events:quic#security`
-* `quic` - `urn:ietf:params:qlog:events:quic#quic`
-* `recovery` - `urn:ietf:params:qlog:events:quic#recovery`
+{{Section 8 of QLOG-MAIN}}, this document registers the `quic` namespace. The
+event schema URI is `urn:ietf:params:qlog:events:quic`.
 
 ## Draft Event Schema Identification
 {:removeinrfc="true"}
 
 Only implementations of the final, published RFC can use the events belonging to
-the category with the URIs `urn:ietf:params:qlog:events:quic#connectivity`,
-`urn:ietf:params:qlog:events:quic#security`,
-`urn:ietf:params:qlog:events:quic#quic`, and
-`urn:ietf:params:qlog:events:quic#recovery`. Until such an RFC exists,
-implementations MUST NOT identify themselves using this URI.
+the event schema with the URI `urn:ietf:params:qlog:events:quic`. Until such an
+RFC exists, implementations MUST NOT identify themselves using this URI.
 
 Implementations of draft versions of the event schema MUST append the string
 "-" and the corresponding draft number to the URI. For example, draft 07 of this
-document is identified using the URI `urn:ietf:params:qlog:events:quic#quic-07`.
+document is identified using the URI `urn:ietf:params:qlog:events:quic-07`.
 
-The category identifier itself is not affected by this requirement.
+The namespace identifier itself is not affected by this requirement.
 
 # QUIC Event Overview
 
@@ -177,17 +168,17 @@ this specification.
 
 | Name value                            | Importance |  Definition |
 |:--------------------------------------|:-----------| :------------|
-| connectivity:server_listening         | Extra      | {{connectivity-serverlistening}} |
-| connectivity:connection_started       | Base       | {{connectivity-connectionstarted}} |
-| connectivity:connection_closed        | Base       | {{connectivity-connectionclosed}} |
-| connectivity:connection_id_updated    | Base       | {{connectivity-connectionidupdated}} |
-| connectivity:spin_bit_updated         | Base       | {{connectivity-spinbitupdated}} |
-| connectivity:connection_state_updated | Base       | {{connectivity-connectionstateupdated}} |
-| connectivity:path_assigned            | Base       | {{connectivity-pathassigned}} |
-| connectivity:mtu_updated              | Extra      | {{connectivity-mtuupdated}} |
-| quic:version_information         | Core       | {{quic-versioninformation}} |
-| quic:alpn_information            | Core       | {{quic-alpninformation}} |
-| quic:parameters_set              | Core       | {{quic-parametersset}} |
+| quic:server_listening         | Extra      | {{quic-serverlistening}} |
+| quic:connection_started       | Base       | {{quic-connectionstarted}} |
+| quic:connection_closed        | Base       | {{quic-connectionclosed}} |
+| quic:connection_id_updated    | Base       | {{quic-connectionidupdated}} |
+| quic:spin_bit_updated         | Base       | {{quic-spinbitupdated}} |
+| quic:connection_state_updated | Base       | {{quic-connectionstateupdated}} |
+| quic:path_assigned            | Base       | {{quic-pathassigned}} |
+| quic:mtu_updated              | Extra      | {{quic-mtuupdated}} |
+| quic:version_information      | Core       | {{quic-versioninformation}} |
+| quic:alpn_information         | Core       | {{quic-alpninformation}} |
+| quic:parameters_set           | Core       | {{quic-parametersset}} |
 | quic:parameters_restored         | Base       | {{quic-parametersrestored}} |
 | quic:packet_sent                 | Core       | {{quic-packetsent}} |
 | quic:packet_received             | Core       | {{quic-packetreceived}} |
@@ -202,15 +193,15 @@ this specification.
 | quic:stream_data_moved                | Base       | {{quic-streamdatamoved}} |
 | quic:datagram_data_moved              | Base       | {{quic-datagramdatamoved}} |
 | quic:migration_state_updated          | Extra      | {{quic-migrationstateupdated}} |
-| security:key_updated                  | Base       | {{security-keyupdated}} |
-| security:key_discarded                | Base       | {{security-keydiscarded}} |
-| recovery:parameters_set               | Base       | {{recovery-parametersset}} |
-| recovery:metrics_updated              | Core       | {{recovery-metricsupdated}} |
-| recovery:congestion_state_updated     | Base       | {{recovery-congestionstateupdated}} |
-| recovery:loss_timer_updated           | Extra      | {{recovery-losstimerupdated}} |
-| recovery:packet_lost                  | Core       | {{recovery-packetlost}} |
-| recovery:marked_for_retransmit        | Extra      | {{recovery-markedforretransmit}} |
-| recovery:ecn_state_updated            | Extra      | {{recovery-ecnstateupdated}} |
+| quic:key_updated                  | Base       | {{quic-keyupdated}} |
+| quic:key_discarded                | Base       | {{quic-keydiscarded}} |
+| quic:recovery_parameters_set               | Base       | {{quic-recoveryparametersset}} |
+| quic:recovery_metrics_updated              | Core       | {{quic-recoverymetricsupdated}} |
+| quic:congestion_state_updated     | Base       | {{quic-congestionstateupdated}} |
+| quic:loss_timer_updated           | Extra      | {{quic-losstimerupdated}} |
+| quic:packet_lost                  | Core       | {{quic-packetlost}} |
+| quic:marked_for_retransmit        | Extra      | {{quic-markedforretransmit}} |
+| quic:ecn_state_updated            | Extra      | {{quic-ecnstateupdated}} |
 {: #quic-events title="QUIC Events"}
 
 QUIC events extend the `$ProtocolEventData` extension point defined in
@@ -219,16 +210,16 @@ per-event extension points via the `$$` CDDL "group socket" syntax, as also
 described in {{QLOG-MAIN}}.
 
 ~~~ cddl
-QuicEventData = ConnectivityServerListening /
-                ConnectivityConnectionStarted /
-                ConnectivityConnectionClosed /
-                ConnectivityConnectionIDUpdated /
-                ConnectivitySpinBitUpdated /
-                ConnectivityConnectionStateUpdated /
-                ConnectivityPathAssigned /
-                ConnectivityMTUUpdated /
-                SecurityKeyUpdated /
-                SecurityKeyDiscarded /
+QuicEventData = QUICServerListening /
+                QUICConnectionStarted /
+                QUICConnectionClosed /
+                QUICConnectionIDUpdated /
+                QUICSpinBitUpdated /
+                QUICConnectionStateUpdated /
+                QUICPathAssigned /
+                QUICMTUUpdated /
+                QUICKeyUpdated /
+                QUICKeyDiscarded /
                 QUICVersionInformation /
                 QUICALPNInformation /
                 QUICParametersSet /
@@ -245,26 +236,30 @@ QuicEventData = ConnectivityServerListening /
                 QUICFramesProcessed /
                 QUICStreamDataMoved /
                 QUICDatagramDataMoved /
-                RecoveryParametersSet /
-                RecoveryMetricsUpdated /
-                RecoveryCongestionStateUpdated /
-                RecoveryLossTimerUpdated /
-                RecoveryPacketLost
+                QUICRecoveryParametersSet /
+                QUICRecoveryMetricsUpdated /
+                QUICCongestionStateUpdated /
+                QUICLossTimerUpdated /
+                QUICPacketLost
 
 $ProtocolEventData /= QuicEventData
 ~~~
 {: #quicevent-data-def title="QuicEventData definition and ProtocolEventData
 extension"}
 
+The concrete QUIC event types are further defined below, their type identifier
+is the heading name. The subdivisions in sections on Connectivity, Security,
+Transport and Recovery are purely for readability.
+
 # Connectivity events {#conn-ev}
 
-## server_listening {#connectivity-serverlistening}
+## server_listening {#quic-serverlistening}
 
 Emitted when the server starts accepting connections. It has Extra importance
 level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-ConnectivityServerListening = {
+QUICServerListening = {
     ? ip_v4: IPAddress
     ? ip_v6: IPAddress
     ? port_v4: uint16
@@ -274,15 +269,15 @@ ConnectivityServerListening = {
     ; (no 1-RTT connection setups by choice)
     ? retry_required: bool
 
-    * $$connectivity-serverlistening-extension
+    * $$quic-serverlistening-extension
 }
 ~~~
-{: #connectivity-serverlistening-def title="ConnectivityServerListening definition"}
+{: #quic-serverlistening-def title="QUICServerListening definition"}
 
 Some QUIC stacks do not handle sockets directly and are thus unable to log
 IP and/or port information.
 
-## connection_started {#connectivity-connectionstarted}
+## connection_started {#quic-connectionstarted}
 
 The `connection_started` event is used for both attempting (client-perspective)
 and accepting (server-perspective) new connections. Note that while there is
@@ -291,7 +286,7 @@ in order to capture additional data that can be useful to log. It has Base
 importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-ConnectivityConnectionStarted = {
+QUICConnectionStarted = {
     ? ip_version: IPVersion
     src_ip: IPAddress
     dst_ip: IPAddress
@@ -303,15 +298,15 @@ ConnectivityConnectionStarted = {
     ? src_cid: ConnectionID
     ? dst_cid: ConnectionID
 
-    * $$connectivity-connectionstarted-extension
+    * $$quic-connectionstarted-extension
 }
 ~~~
-{: #connectivity-connectionstarted-def title="ConnectivityConnectionStarted definition"}
+{: #quic-connectionstarted-def title="QUICConnectionStarted definition"}
 
 Some QUIC stacks do not handle sockets directly and are thus unable to log
 IP and/or port information.
 
-## connection_closed {#connectivity-connectionclosed}
+## connection_closed {#quic-connectionclosed}
 
 The `connection_closed` event is used for logging when a connection was closed,
 typically when an error or timeout occurred. It has Base importance level; see
@@ -341,7 +336,7 @@ mapped to the official error codes in implementation-specific ways. As such,
 multiple error codes can be set on the same event to reflect this.
 
 ~~~ cddl
-ConnectivityConnectionClosed = {
+QUICConnectionClosed = {
 
     ; which side closed the connection
     ? owner: Owner
@@ -362,10 +357,10 @@ ConnectivityConnectionClosed = {
         ; when it is unclear what triggered the CONNECTION_CLOSE
         "unspecified"
 
-    * $$connectivity-connectionclosed-extension
+    * $$quic-connectionclosed-extension
 }
 ~~~
-{: #connectivity-connectionclosed-def title="ConnectivityConnectionClosed definition"}
+{: #quic-connectionclosed-def title="QUICConnectionClosed definition"}
 
 Loggers SHOULD use the most descriptive trigger for a `connection_closed` event
 that they are able to deduce. This is often clear at the peer closing the
@@ -373,7 +368,7 @@ connection (and sending the CONNECTION_CLOSE), but can sometimes be more opaque
 at the receiving end.
 
 
-## connection_id_updated {#connectivity-connectionidupdated}
+## connection_id_updated {#quic-connectionidupdated}
 
 The `connection_id_updated` event is emitted when either party updates their
 current Connection ID. As this typically happens only sparingly over the course
@@ -387,17 +382,17 @@ from the peer, the owner field will be "remote". When the endpoint updates its
 own connection ID, the owner field will be "local".
 
 ~~~ cddl
-ConnectivityConnectionIDUpdated = {
+QUICConnectionIDUpdated = {
     owner: Owner
     ? old: ConnectionID
     ? new: ConnectionID
 
-    * $$connectivity-connectionidupdated-extension
+    * $$quic-connectionidupdated-extension
 }
 ~~~
-{: #connectivity-connectionidupdated-def title="ConnectivityConnectionIDUpdated definition"}
+{: #quic-connectionidupdated-def title="QUICConnectionIDUpdated definition"}
 
-## spin_bit_updated {#connectivity-spinbitupdated}
+## spin_bit_updated {#quic-spinbitupdated}
 
 The `spin_bit_updated` event conveys information about the QUIC latency spin
 bit; see {{Section 17.4 of QUIC-TRANSPORT}}. The event is emitted when the spin
@@ -406,15 +401,15 @@ changing its value. It has Base importance level; see {{Section 9.2 of
 QLOG-MAIN}}.
 
 ~~~ cddl
-ConnectivitySpinBitUpdated = {
+QUICSpinBitUpdated = {
     state: bool
 
-    * $$connectivity-spinbitupdated-extension
+    * $$quic-spinbitupdated-extension
 }
 ~~~
-{: #connectivity-spinbitupdated-def title="ConnectivitySpinBitUpdated definition"}
+{: #quic-spinbitupdated-def title="QUICSpinBitUpdated definition"}
 
-## connection_state_updated {#connectivity-connectionstateupdated}
+## connection_state_updated {#quic-connectionstateupdated}
 
 The `connection_state_updated` event is used to track progress through QUIC's
 complex handshake and connection close procedures. It has Base importance
@@ -431,11 +426,11 @@ adding the more fine-grained GranularConnectionStates when more in-depth
 debugging is required. Tools SHOULD be able to deal with both types equally.
 
 ~~~ cddl
-ConnectivityConnectionStateUpdated = {
+QUICConnectionStateUpdated = {
     ? old: $ConnectionState
     new: $ConnectionState
 
-    * $$connectivity-connectionstateupdated-extension
+    * $$quic-connectionstateupdated-extension
 }
 
 BaseConnectionStates =
@@ -445,12 +440,14 @@ BaseConnectionStates =
     ; Handshake packet sent/received
     "handshake_started" /
 
-    ; Both sent a TLS Finished message and verified the peer's TLS Finished message
+    ; Both sent a TLS Finished message
+    ; and verified the peer's TLS Finished message
     ; 1-RTT packets can be sent
     ; RFC 9001 Section 4.1.1
     "handshake_complete" /
 
-    ; CONNECTION_CLOSE sent/received, stateless reset received or idle timeout
+    ; CONNECTION_CLOSE sent/received,
+    ; stateless reset received or idle timeout
     "closed"
 
 GranularConnectionStates =
@@ -460,7 +457,8 @@ GranularConnectionStates =
     ; client used valid address validation token
     "peer_validated" /
 
-    ; 1-RTT data can be sent by the server, but handshake is not done yet
+    ; 1-RTT data can be sent by the server,
+    ; but handshake is not done yet
     ; (server has sent TLS Finished; sometimes called 0.5 RTT data)
     "early_write" /
 
@@ -479,7 +477,7 @@ GranularConnectionStates =
 
 $ConnectionState /= BaseConnectionStates / GranularConnectionStates
 ~~~
-{: #connectivity-connectionstateupdated-def title="ConnectivityConnectionStateUpdated definition"}
+{: #quic-connectionstateupdated-def title="QUICConnectionStateUpdated definition"}
 
 The `connection_state_changed` event has some overlap with the
 `connection_closed` and `connection_started` events, and the handling of various
@@ -490,7 +488,7 @@ implementations are allowed to use other ConnectionState values that adhere more
 closely to their internal logic. Tools SHOULD be able to deal with these custom
 states in a similar way to the pre-defined states in this document.
 
-## path_assigned {#connectivity-pathassigned}
+## path_assigned {#quic-pathassigned}
 Importance: Base
 
 This event is used to associate a single PathID's value with other parameters
@@ -507,7 +505,7 @@ evolves.
 Definition:
 
 ~~~ cddl
-ConnectivityPathAssigned = {
+QUICPathAssigned = {
     path_id: PathID
 
     ; the information for traffic going towards the remote receiver
@@ -516,10 +514,10 @@ ConnectivityPathAssigned = {
     ; the information for traffic coming in at the local endpoint
     ? path_local: PathEndpointInfo
 
-    * $$connectivity-pathassigned-extension
+    * $$quic-pathassigned-extension
 }
 ~~~
-{: #connectivity-pathassigned-def title="ConnectivityPathAssigned definition"}
+{: #quic-pathassigned-def title="QUICPathAssigned definition"}
 
 Choosing the different `path_id` values is left up to the implementation. Some
 options include using a uniquely incrementing integer, using the (first)
@@ -529,27 +527,26 @@ using (a hash of) the two endpoint IP addresses.
 It is important to note that the empty string ("") is a valid PathID and that it
 is the default assigned to events that do not explicitly set a "path" field. Put
 differently, the initial path of a QUIC connection on which the handshake occurs
-(see also {{connectivity-connectionstarted}}) is implicitly associated with the
-PathID with value "". Associating metadata with this default path is possible by
-logging the ConnectivityPathAssigned event with a value of "" for the `path_id`
-field.
+(see also {{quic-connectionstarted}}) is implicitly associated with the PathID
+with value "". Associating metadata with this default path is possible by
+logging the QUICPathAssigned event with a value of "" for the `path_id` field.
 
-As paths and their metadata can evolve over time, multiple
-ConnectivityPathAssigned events can be emitted for each unique PathID. The
-latest event contains the most up-to-date information for that PathID. As such,
-the first time a PathID is seen in a ConnectivityPathAssigned event, it is an
-indication that the path is created. Subsequent occurrences indicate the path is
-updated, while a final occurrence with both `path_local` and `path_remote`
-fields omitted implicitly indicates the path has been abandoned.
+As paths and their metadata can evolve over time, multiple QUICPathAssigned
+events can be emitted for each unique PathID. The latest event contains the most
+up-to-date information for that PathID. As such, the first time a PathID is seen
+in a QUICPathAssigned event, it is an indication that the path is
+created. Subsequent occurrences indicate the path is updated, while a final
+occurrence with both `path_local` and `path_remote` fields omitted implicitly
+indicates the path has been abandoned.
 
-## mtu_updated {#connectivity-mtuupdated}
+## mtu_updated {#quic-mtuupdated}
 
 The `mtu_updated` event indicates that the estimated Path MTU was updated. This
 happens as part of the Path MTU discovery process. It has Extra importance
 level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-ConnectivityMTUUpdated = {
+QUICMTUUpdated = {
     ? old: uint32
     new: uint32
 
@@ -557,12 +554,12 @@ ConnectivityMTUUpdated = {
     ; packet size has been found
     ? done: bool .default false
 
-    * $$connectivity-mtuupdated-extension
+    * $$quic-mtuupdated-extension
 }
 ~~~
-{: #connectivity-mtuupdated-def title="ConnectivityMTUUpdated definition"}
+{: #quic-mtuupdated-def title="QUICMTUUpdated definition"}
 
-# QUIC events  {#quic-ev}
+# Transport events  {#quic-ev}
 
 ## version_information {#quic-versioninformation}
 
@@ -1254,14 +1251,14 @@ QUICDatagramDataMoved = {
 {: #quic-datagramdatamoved-def title="QUICDatagramDataMoved definition"}
 
 ## migration_state_updated {#quic-migrationstateupdated}
-Importance: Extra
 
 Use to provide additional information when attempting (client-side) connection
 migration. While most details of the QUIC connection migration process can be
 inferred by observing the PATH_CHALLENGE and PATH_RESPONSE frames, in
-combination with the ConnectivityPathAssigned event, it can be useful to
-explicitly log the progression of the migration and potentially made decisions
-in a single location/event.
+combination with the QUICPathAssigned event, it can be useful to explicitly log
+the progression of the migration and potentially made decisions in a single
+location/event. The event has Extra importance level; see {{Section 9.2 of
+QLOG-MAIN}}.
 
 Generally speaking, connection migration goes through two phases: a probing
 phase (which is not always needed/present), and a migration phase (which can be
@@ -1312,12 +1309,12 @@ MigrationState =
 
 # Security Events {#sec-ev}
 
-## key_updated {#security-keyupdated}
+## key_updated {#quic-keyupdated}
 
 The `key_updated` event has Base importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-SecurityKeyUpdated = {
+QUICKeyUpdated = {
     key_type: $KeyType
     ? old: hexstring
     ? new: hexstring
@@ -1334,19 +1331,19 @@ SecurityKeyUpdated = {
     * $$quic-keyupdated-extension
 }
 ~~~
-{: #security-keyupdated-def title="SecurityKeyUpdated definition"}
+{: #quic-keyupdated-def title="QUICKeyUpdated definition"}
 
 Note that the key_phase is the full value of the key phase (as indicated by
 @M and @N in Figure 9 of {{QUIC-TLS}}). The key phase bit used on
 the packet header is the least significant bit of the key phase.
 
-## key_discarded {#security-keydiscarded}
+## key_discarded {#quic-keydiscarded}
 
 The `key_discarded` event has Base importance level; see {{Section 9.2 of
 QLOG-MAIN}}.
 
 ~~~ cddl
-SecurityKeyDiscarded = {
+QUICKeyDiscarded = {
     key_type: $KeyType
     ? key: hexstring
 
@@ -1362,7 +1359,7 @@ SecurityKeyDiscarded = {
     * $$quic-keydiscarded-extension
 }
 ~~~
-{: #security-keydiscarded-def title="SecurityKeyDiscarded definition"}
+{: #quic-keydiscarded-def title="QUICKeyDiscarded definition"}
 
 # Recovery events {#rec-ev}
 
@@ -1371,18 +1368,18 @@ recovery approaches and various congestion control algorithms. Tool creators
 SHOULD make an effort to support and visualize even unknown data in these events
 (e.g., plot unknown congestion states by name on a timeline visualization).
 
-## parameters_set {#recovery-parametersset}
+## recovery_parameters_set {#quic-recoveryparametersset}
 
-The `parameters_set` event groups initial parameters from both loss detection
-and congestion control into a single event. It has Base importance level; see
-{{Section 9.2 of QLOG-MAIN}}.
+The `recovery_parameters_set` event groups initial parameters from both loss
+detection and congestion control into a single event. It has Base importance
+level; see {{Section 9.2 of QLOG-MAIN}}.
 
 All these settings are typically set once and never change. Implementation that
 do, for some reason, change these parameters during execution, MAY emit the
-`parameters_set` event more than once.
+`recovery_parameters_set` event more than once.
 
 ~~~ cddl
-RecoveryParametersSet = {
+QUICRecoveryParametersSet = {
 
     ; Loss detection, see RFC 9002 Appendix A.2
     ; in amount of packets
@@ -1412,28 +1409,28 @@ RecoveryParametersSet = {
     ; as PTO multiplier
     ? persistent_congestion_threshold: uint16
 
-    * $$recovery-parametersset-extension
+    * $$quic-recoveryparametersset-extension
 }
 ~~~
-{: #recovery-parametersset-def title="RecoveryParametersSet definition"}
+{: #quic-recoveryparametersset-def title="QUICRecoveryParametersSet definition"}
 
 Additionally, this event can contain any number of unspecified fields to support
 different recovery approaches.
 
-## metrics_updated {#recovery-metricsupdated}
+## recovery_metrics_updated {#quic-recoverymetricsupdated}
 
-The `metrics_updated` event is emitted when one or more of the observable
+The `recovery_metrics_updated` event is emitted when one or more of the observable
 recovery metrics changes value. It has Core importance level; see {{Section
 9.2 of QLOG-MAIN}}.
 
 This event SHOULD group all possible metric updates that happen at or around the
 same time in a single event (e.g., if `min_rtt` and `smoothed_rtt` change at the
-same time, they should be bundled in a single `metrics_updated` entry, rather
-than split out into two). Consequently, a `metrics_updated` event is only
-guaranteed to contain at least one of the listed metrics.
+same time, they should be bundled in a single `recovery_metrics_updated` entry,
+rather than split out into two). Consequently, a `recovery_metrics_updated`
+event is only guaranteed to contain at least one of the listed metrics.
 
 ~~~ cddl
-RecoveryMetricsUpdated = {
+QUICRecoveryMetricsUpdated = {
 
     ; Loss detection, see RFC 9002 Appendix A.3
     ; all following rtt fields are expressed in ms
@@ -1458,20 +1455,21 @@ RecoveryMetricsUpdated = {
     ; in bits per second
     ? pacing_rate: uint64
 
-    * $$recovery-metricsupdated-extension
+    * $$quic-recoverymetricsupdated-extension
 }
 ~~~
-{: #recovery-metricsupdated-def title="RecoveryMetricsUpdated definition"}
+{: #quic-recoverymetricsupdated-def title="QUICRecoveryMetricsUpdated definition"}
 
-In order to make logging easier, implementations MAY log values even if they are the
-same as previously reported values (e.g., two subsequent RecoveryMetricsUpdated entries can
-both report the exact same value for `min_rtt`). However, applications SHOULD try to
-log only actual updates to values.
+In order to make logging easier, implementations MAY log values even if they are
+the same as previously reported values (e.g., two subsequent
+QUICRecoveryMetricsUpdated entries can both report the exact same value for
+`min_rtt`). However, applications SHOULD try to log only actual updates to
+values.
 
-Additionally, the `metrics_updated` event can contain any number of unspecified fields to support
-different recovery approaches.
+Additionally, the `recovery_metrics_updated` event can contain any number of
+unspecified fields to support different recovery approaches.
 
-## congestion_state_updated {#recovery-congestionstateupdated}
+## congestion_state_updated {#quic-congestionstateupdated}
 
 The `congestion_state_updated` event indicates when the congestion controller
 enters a significant new state and changes its behaviour. It has Base importance
@@ -1480,29 +1478,29 @@ level; see {{Section 9.2 of QLOG-MAIN}}.
 The values of the event's fields are intentionally unspecified here in order to
 support different Congestion Control algorithms, as these typically have
 different states and even different implementations of these states across
-stacks. For example, for the algorithm defined in the Recovery draft ("enhanced"
-New Reno), the following states are used: Slow Start, Congestion Avoidance,
-Application Limited and Recovery. Similarly, states can be triggered by a
-variety of events, including detection of Persistent Congestion or receipt of
-ECN markings.
+stacks. For example, for the algorithm defined in the QUIC Recovery RFC
+("enhanced" New Reno), the following states are used: Slow Start, Congestion
+Avoidance, Application Limited and Recovery. Similarly, states can be triggered
+by a variety of events, including detection of Persistent Congestion or receipt
+of ECN markings.
 
 ~~~ cddl
-RecoveryCongestionStateUpdated = {
+QUICCongestionStateUpdated = {
     ? old: text
     new: text
     ? trigger: text
 
-    * $$recovery-congestionstateupdated-extension
+    * $$quic-congestionstateupdated-extension
 }
 ~~~
-{: #recovery-congestionstateupdated-def title="RecoveryCongestionStateUpdated definition"}
+{: #quic-congestionstateupdated-def title="QUICCongestionStateUpdated definition"}
 
 The `trigger` field SHOULD be logged if there are multiple ways in which a state
 change can occur but MAY be omitted if a given state can only be due to a single
 event occurring (for example Slow Start is often exited only when ssthresh is
 exceeded).
 
-## loss_timer_updated {#recovery-losstimerupdated}
+## loss_timer_updated {#quic-losstimerupdated}
 
 The `loss_timer_updated` event is emitted when a recovery loss timer changes
 state. It has Extra importance level; see {{Section 9.2 of QLOG-MAIN}}.
@@ -1517,7 +1515,7 @@ The three main event types are:
 In order to indicate an active timer's timeout update, a new `set` event is used.
 
 ~~~ cddl
-RecoveryLossTimerUpdated = {
+QUICLossTimerUpdated = {
 
     ; called "mode" in RFC 9002 A.9.
     ? timer_type: "ack" /
@@ -1531,12 +1529,12 @@ RecoveryLossTimerUpdated = {
     ; this event's timestamp until when the timer will trigger
     ? delta: float32
 
-    * $$recovery-losstimerupdated-extension
+    * $$quic-losstimerupdated-extension
 }
 ~~~
-{: #recovery-losstimerupdated-def title="RecoveryLossTimerUpdated definition"}
+{: #quic-losstimerupdated-def title="QUICLossTimerUpdated definition"}
 
-## packet_lost {#recovery-packetlost}
+## packet_lost {#quic-packetlost}
 
 The `packet_lost` event is emitted when a packet is deemed lost by loss
 detection. It has Core importance level; see {{Section 9.2 of QLOG-MAIN}}.
@@ -1545,7 +1543,7 @@ It is RECOMMENDED to populate the optional `trigger` field in order to help
 disambiguate among the various possible causes of a loss declaration.
 
 ~~~ cddl
-RecoveryPacketLost = {
+QUICPacketLost = {
 
     ; should include at least the packet_type and packet_number
     ? header: PacketHeader
@@ -1560,12 +1558,12 @@ RecoveryPacketLost = {
         ; RFC 9002 Section 6.2.4 paragraph 6, MAY
         "pto_expired"
 
-    * $$recovery-packetlost-extension
+    * $$quic-packetlost-extension
 }
 ~~~
-{: #recovery-packetlost-def title="RecoveryPacketLost definition"}
+{: #quic-packetlost-def title="QUICPacketLost definition"}
 
-## marked_for_retransmit {#recovery-markedforretransmit}
+## marked_for_retransmit {#quic-markedforretransmit}
 
 The `marked_for_retransmit` event indicates which data was marked for
 retransmission upon detection of packet loss (see `packet_lost`). It has Extra
@@ -1589,26 +1587,26 @@ Much of this data can be inferred if implementations log `packet_sent` events
 when data was retransmitted).
 
 ~~~ cddl
-RecoveryMarkedForRetransmit = {
+QUICMarkedForRetransmit = {
     frames: [+ $QuicFrame]
 
-    * $$recovery-markedforretransmit-extension
+    * $$quic-markedforretransmit-extension
 }
 ~~~
-{: #recovery-markedforretransmit-def title="RecoveryMarkedForRetransmit definition"}
+{: #quic-markedforretransmit-def title="QUICMarkedForRetransmit definition"}
 
-## ecn_state_updated {#recovery-ecnstateupdated}
+## ecn_state_updated {#quic-ecnstateupdated}
 
 The `ecn_state_updated` event indicates a progression in the ECN state machine
 as described in section A.4 of {{QUIC-TRANSPORT}}. It has Extra importance
 level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
-ECNStateUpdated = {
+QUICECNStateUpdated = {
    ? old: ECNState
     new: ECNState
 
-    * $$recovery-ecnstateupdated-extension
+    * $$quic-ecnstateupdated-extension
 }
 
 ECNState =
@@ -1623,10 +1621,10 @@ ECNState =
   ; sends packets with ECT(0) marking
   "capable"
 ~~~
-{: #recovery-ecnstateupdated-def title="ECNStateUpdated definition"}
+{: #quic-ecnstateupdated-def title="QUICECNStateUpdated definition"}
 
 
-# QUIC data field definitions
+# QUIC data type definitions
 
 ## QuicVersion
 
@@ -2269,44 +2267,22 @@ document as well.
 
 # IANA Considerations
 
-This document registers several new entries in the "qlog event category URIs"
-registry.
+This document registers a new entry in the "qlog event schema URIs" registry:
 
-Event Category URI:
-: urn:ietf:params:qlog:events:quic#connectivity
+Event schema URI:
+: urn:ietf:params:qlog:events:quic
 
-Description:
-: Event definitions related to QUIC connectivity.
+Namespace
+: quic
 
-Reference:
-: {{conn-ev}}
-
-Event Category URI:
-: urn:ietf:params:qlog:events:quic#security
+Event Types
+: TODO ROBIN
 
 Description:
-: Event definitions related to QUIC security.
+: Event definitions related to the QUIC transport protocol.
 
 Reference:
-: {{sec-ev}}
-
-Event Category URI:
-: urn:ietf:params:qlog:events:quic#quic
-
-Description:
-: Event definitions related to the QUIC wire image and other concerns.
-
-Reference:
-: {{quic-ev}}
-
-Event Category URI:
-: urn:ietf:params:qlog:events:quic#recovery
-
-Description:
-: Event definitions related to QUIC recovery.
-
-Reference:
-: {{conn-ev}}
+: This Document
 
 --- back
 

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2276,7 +2276,7 @@ Namespace
 : quic
 
 Event Types
-: TODO ROBIN
+: server_listening,connection_started,connection_closed,connection_id_updated,spin_bit_updated,connection_state_updated,path_assigned,mtu_updated,version_information,alpn_information,parameters_set,parameters_restored,packet_sent,packet_received,packet_dropped,packet_buffered,packets_acked,udp_datagrams_sent,udp_datagrams_received,udp_datagram_dropped,stream_state_updated,frames_processed,stream_data_moved,datagram_data_moved,migration_state_updated,key_updated,key_discarded,recovery_parameters_set,recovery_metrics_updated,congestion_state_updated,loss_timer_updated,packet_lost,marked_for_retransmit,ecn_state_updated
 
 Description:
 : Event definitions related to the QUIC transport protocol.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -72,7 +72,7 @@ containing concrete events for the core QUIC protocol (see
 {{!QUIC-DATAGRAM=RFC9221}} and {{!GREASEBIT=RFC9287}}).
 
 
-The event namespace with identifier `http3` is defined; see {{schema-def}}. In
+The event namespace with identifier `quic` is defined; see {{schema-def}}. In
 this namespace multiple events derive from the qlog abstract Event class
 ({{Section 7 of QLOG-MAIN}}), each extending the "data" field and defining their
 "name" field values and semantics. Some event data fields use complex data


### PR DESCRIPTION
As discussed during today's editors meeting with @LPardue, I feel it would be better and simpler overall to just remove the notion of event categories and only have event `namespaces` to group event types by. 

This simplifies handling extensions and schema URIs considerably, while also allowing us to more easily extend existing namespaces with new events (e.g., QUIC extensions can be properly tagged as `quic:my_new_event` instead of `my_quic_extension:my_new_event` which would otherwise have been needed).

Categories were originally needed because I had the vision of reusable event types across protocols (hence stuff in the `connectivity` or `security` categories would be re-usable across both TPC and QUIC for example). In practice, this has turned out to be a pipe dream and the QUIC document has also moved away from that in all but name (and the HTTP/3 document just had a single category anyway). 

(note: Friday 18 oct 4PM CEST: not fully ready yet; still need to remove the categories notion from QUIC and H3 docs, but the main doc text should be ready for review already)

