### PR TITLE
Add event_schemas to examples

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -347,6 +347,7 @@ JSON serialization example:
     "serialization_format": "application/qlog+json",
     "title": "Name of this particular qlog file (short)",
     "description": "Description for this group of traces (long)",
+    "event_schemas": ["urn:ietf:params:qlog:events:quic"],
     "traces": [...]
 }
 ~~~
@@ -492,6 +493,7 @@ JSON-SEQ serialization example:
     "serialization_format": "application/qlog+json-seq",
     "title": "Name of JSON Text Sequence qlog file (short)",
     "description": "Description for this trace file (long)",
+    "event_schemas": ["urn:ietf:params:qlog:events:quic"],
     "trace": {
       "common_fields": {
         "protocol_types": ["QUIC","HTTP/3"],

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -493,7 +493,7 @@ JSON-SEQ serialization example:
     "serialization_format": "application/qlog+json-seq",
     "title": "Name of JSON Text Sequence qlog file (short)",
     "description": "Description for this trace file (long)",
-    "event_schemas": ["urn:ietf:params:qlog:events:quic"],
+    "event_schemas": ["urn:ietf:params:qlog:events:quic", "urn:ietf:params:qlog:events:http3"],
     "trace": {
       "common_fields": {
         "protocol_types": ["QUIC","HTTP/3"],


### PR DESCRIPTION
According to [section 3](https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema-10#section-3), event_schemas is required.