### PR TITLE
Editorial work of triggers

### DIFF
--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1317,7 +1317,7 @@ $$quic-packetsent-extension //= (
 
 ### Triggers {#trigger-field}
 
-It can be is useful to understand the cause or trigger of an event. Sometimes,
+It can be useful to understand the cause or trigger of an event. Sometimes,
 events are caused by a variety of other events and additional information is
 needed to identify the exact details. Commonly, the context of the surrounding
 log messages gives a hint about the cause. However, in highly-parallel and

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -1231,25 +1231,20 @@ is the extensible `$ProtocolEventData` type. This field acts as an open enum of
 possible types that are allowed for the data field. As such, any new event data
 field is defined as its own CDDL type and later merged with the existing
 `$ProtocolEventData` enum using the `/=` extension operator. Any generic
-key-value map type can be assigned to `$ProtocolEventData` (the only common
-"data" subfield defined in this document is the optional `trigger` field, see
-{{trigger-field}}). An example of this setup is shown in
-{{protocoleventdata-def}}.
+key-value map type can be assigned to `$ProtocolEventData`. The example in
+{{protocoleventdata-def}} demonstrates `$ProtocolEventData` being extended with
+two types.
 
 ~~~~~~~~
 ; We define two new concrete events in a new event schema
 MyNSEvent1 /= {
     field_1: uint8
 
-    ? trigger: text
-
     * $$myns-event1-extension
 }
 
 MyNSEvent2 /= {
     field_2: bool
-
-    ? trigger: text
 
     * $$myns-event2-extension
 }
@@ -1322,36 +1317,44 @@ $$quic-packetsent-extension //= (
 
 ### Triggers {#trigger-field}
 
-Sometimes, additional information is needed in the case where a single event can
-be caused by a variety of other events. In the normal case, the context of the
-surrounding log messages gives a hint as to which of these other events was the
-cause. However, in highly-parallel and optimized implementations, corresponding
-log messages might separated in time. Another option is to explicitly indicate
-these "triggers" in a high-level way per-event to get more fine-grained
-information without much additional overhead.
+It can be is useful to understand the cause or trigger of an event. Sometimes,
+events are caused by a variety of other events and additional information is
+needed to identify the exact details. Commonly, the context of the surrounding
+log messages gives a hint about the cause. However, in highly-parallel and
+optimized implementations, corresponding log messages might be separated in
+time, making it difficult to build an accurate context.
 
-In qlog, the optional "trigger" field contains a string value describing
-the reason (if any) for this event instance occurring, see
-{{data-field}}. While this "trigger" field could be a property of the
-qlog Event itself, it is instead a property of the "data" field instead.
-This choice was made because many event types do not include a trigger
-value, and having the field at the Event-level would cause overhead in
-some serializations. Additional information on the trigger can be added
-in the form of additional member fields of the "data" field value, yet
-this is highly implementation-specific, as are the trigger field's
-string values.
+Including a "trigger" as part of the event itself is one method for providing
+fine-grained information without much additional overhead. In circumstances
+where a trigger is useful, it is RECOMMENDED for the purpose of consistency that
+the event data definition contains an optional field named "trigger", holding a
+string value.
 
-One purely illustrative example of some potential triggers for QUIC's
-"packet_dropped" event is shown in {{trigger-ex}}:
+For example, the QUIC "packet_dropped" event ({{Section 5.7 of QLOG-QUIC}})
+includes a trigger field that identifies the precise reason why a QUIC packet
+was dropped:
 
 ~~~~~~~~
-TransportPacketDropped = {
-    ? packet_type: PacketType
-    ? raw_length: uint16
-    ? trigger: "key_unavailable" /
-               "unknown_connection_id" /
-               "decrypt_error" /
-               "unsupported_version"
+QUICPacketDropped = {
+
+    ; Primarily packet_type should be filled here,
+    ; as other fields might not be decrypteable or parseable
+    ? header: PacketHeader
+    ? raw: RawInfo
+    ? datagram_id: uint32
+    ? details: {* text => any}
+    ? trigger:
+        "internal_error" /
+        "rejected" /
+        "unsupported" /
+        "invalid" /
+        "duplicate" /
+        "connection_unknown" /
+        "decryption_failure" /
+        "key_unavailable" /
+        "general"
+
+    * $$quic-packetdropped-extension
 }
 ~~~~~~~~
 {: #trigger-ex title="Trigger example"}


### PR DESCRIPTION
As discussed on https://github.com/quicwg/qlog/issues/429, it seems like a better option to just RECOMMEND a "trigger" field if an event would benefit from an explicit trigger.

This change removes the mention of triggers from the parent section (8.2) and puts the normative sugestion in the trigger section (8.2.1)

Closes https://github.com/quicwg/qlog/issues/429