### PR TITLE
Update QUICConnectionStarted event

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -289,7 +289,7 @@ importance level; see {{Section 9.2 of QLOG-MAIN}}.
 QUICConnectionStarted = {
     local: PathEndpointInfo
     remote: PathEndpointInfo
-    
+
     * $$quic-connectionstarted-extension
 }
 ~~~

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -287,17 +287,9 @@ importance level; see {{Section 9.2 of QLOG-MAIN}}.
 
 ~~~ cddl
 QUICConnectionStarted = {
-    ? ip_version: IPVersion
-    src_ip: IPAddress
-    dst_ip: IPAddress
-
-    ; transport layer protocol
-    ? protocol: text .default "QUIC"
-    ? src_port: uint16
-    ? dst_port: uint16
-    ? src_cid: ConnectionID
-    ? dst_cid: ConnectionID
-
+    local: PathEndpointInfo
+    remote: PathEndpointInfo
+    
     * $$quic-connectionstarted-extension
 }
 ~~~


### PR DESCRIPTION
We've had issue #119 open for over 4 years. It proposed a few options
with the preference towards option 3, which related to #57 and #79.
Both of those issues have been fixed. In parallel, we've also got rid
of the notion of generic "transport" events and everything is framed
in terms of QUIC now.

More to the point, we added the PathEndpointInfo type that contains
all the same sorts of information that's needed, and it has text that
describes directionality aspects that #119 was concerned about.
Therefore, I lets just use that.

Also remove the `protocol` field now that the event is purely QUIC.

Closes #119
