### PR TITLE
make the IPv4 and IPv6 2-tuple in the PreferredAddress optional

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -712,10 +712,10 @@ QUICParametersSet = {
 }
 
 PreferredAddress = {
-    ip_v4: IPAddress
-    ip_v6: IPAddress
-    port_v4: uint16
-    port_v6: uint16
+    ? ip_v4: IPAddress
+    ? port_v4: uint16
+    ? ip_v6: IPAddress
+    ? port_v6: uint16
     connection_id: ConnectionID
     stateless_reset_token: StatelessResetToken
 }


### PR DESCRIPTION
According to section 18.2 of RFC 9000, the server MAY only send one (valid) address:
> Servers MAY choose to only send a preferred address of one address family by sending an all-zero address and port (0.0.0.0:0 or [::]:0) for the other family. IP addresses are encoded in network byte order.

In that case, it should be valid to just not log the invalid address.