### PR TITLE
Added missing events to QuicEventData

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -209,8 +209,6 @@ QuicEventData = QUICServerListening /
                 QUICConnectionStateUpdated /
                 QUICPathAssigned /
                 QUICMTUUpdated /
-                QUICKeyUpdated /
-                QUICKeyDiscarded /
                 QUICVersionInformation /
                 QUICALPNInformation /
                 QUICParametersSet /
@@ -227,11 +225,16 @@ QuicEventData = QUICServerListening /
                 QUICFramesProcessed /
                 QUICStreamDataMoved /
                 QUICDatagramDataMoved /
+                QUICMigrationStateUpdated /
+                QUICKeyUpdated /
+                QUICKeyDiscarded /
                 QUICRecoveryParametersSet /
                 QUICRecoveryMetricsUpdated /
                 QUICCongestionStateUpdated /
                 QUICLossTimerUpdated /
-                QUICPacketLost
+                QUICPacketLost /
+                QUICMarkedForRetransmit /
+                QUICEcnStateUpdated
 
 $ProtocolEventData /= QuicEventData
 ~~~

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -234,7 +234,7 @@ QuicEventData = QUICServerListening /
                 QUICLossTimerUpdated /
                 QUICPacketLost /
                 QUICMarkedForRetransmit /
-                QUICEcnStateUpdated
+                QUICECNStateUpdated
 
 $ProtocolEventData /= QuicEventData
 ~~~


### PR DESCRIPTION
I noticed that 3 events were missing from `QuicEventData` (`QUICMigrationStateUpdated`, `QUICMarkedForRetransmit`, and `QUICEcnStateUpdated`), so I added these. The security events (`QUICKeyUpdated` and `QUICKeyDiscarded`) were placed above the transport events, while the text has it the other way around, so I moved these so `QuicEventData` has the same order as the text.