### PR TITLE
Remove references to stale concrete examples

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -64,10 +64,6 @@ Feedback and discussion are welcome at
 advised to refer to the "editor's draft" at that URL for an up-to-date version
 of this document.
 
-Concrete examples of integrations of this schema in
-various programming languages can be found at
-[https://github.com/quiclog/qlog/](https://github.com/quiclog/qlog/).
-
 --- middle
 
 # Introduction

--- a/draft-ietf-quic-qlog-main-schema.md
+++ b/draft-ietf-quic-qlog-main-schema.md
@@ -80,10 +80,6 @@ Feedback and discussion are welcome at
 advised to refer to the "editor's draft" at that URL for an up-to-date version
 of this document.
 
-Concrete examples of integrations of this schema in
-various programming languages can be found at
-[https://github.com/quiclog/qlog/](https://github.com/quiclog/qlog/).
-
 --- middle
 
 # Introduction

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -57,10 +57,6 @@ Feedback and discussion are welcome at
 advised to refer to the "editor's draft" at that URL for an up-to-date version
 of this document.
 
-Concrete examples of integrations of this schema in
-various programming languages can be found at
-[https://github.com/quiclog/qlog/](https://github.com/quiclog/qlog/).
-
 --- middle
 
 # Introduction


### PR DESCRIPTION
Although this in included in a note for the RFC editor to remove,
there seems little point in directing anyone else in the meantime
to stale stuff. So lets remove the pointers.
