### PR TITLE
Tweak stream_state_updated

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1059,6 +1059,11 @@ inferred from several types of frames going over the wire, but it's much easier
 to have explicit signals for these state changes. The event has Base importance
 level.
 
+While stream IDs encode the type of stream and its initiator, the optional
+`stream_type` and `initiator` fields can be used to provide a more-accessible
+form of the information.
+
+
 ~~~ cddl
 StreamType = "unidirectional" /
              "bidirectional"
@@ -1068,10 +1073,13 @@ QUICStreamStateUpdated = {
 
     ; mainly useful when opening the stream
     ? stream_type: StreamType
+    ? initiator: "client" /
+                 "server"
+
     ? old: $StreamState
     new: $StreamState
-    ? stream_side: "sending" /
-                   "receiving"
+    stream_side: "sending" /
+                 "receiving"
 
     * $$quic-streamstateupdated-extension
 }


### PR DESCRIPTION
This implements my suggestions from #374, adding a new optional
initiator field to supplement the stream_type field, along with
making the stream_side field mandatory.

Having just implemented a prototype pcap to qlog tool, that tool
needs to try and build an understanding of who is a QUIC server
and client, and in what direction messages are flowing. So even
an observer vantage point can determine and log `stream_side`.

Closes #374
