### PR TITLE
Break long lines

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -768,7 +768,15 @@ Namespace
 : http3
 
 Event Types
-: parameters_set,parameters_restored,stream_type_set,priority_updated,frame_created,frame_parsed,datagram_created,datagram_parsed,push_resolved
+: parameters_set,
+  parameters_restored,
+  stream_type_set,
+  priority_updated,
+  frame_created,
+  frame_parsed,
+  datagram_created,
+  datagram_parsed,
+  push_resolved
 
 Description:
 : Event definitions related to the HTTP/3 application protocol.

--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2382,7 +2382,40 @@ Namespace
 : quic
 
 Event Types
-: server_listening,connection_started,connection_closed,connection_id_updated,spin_bit_updated,connection_state_updated,path_assigned,mtu_updated,version_information,alpn_information,parameters_set,parameters_restored,packet_sent,packet_received,packet_dropped,packet_buffered,packets_acked,udp_datagrams_sent,udp_datagrams_received,udp_datagram_dropped,stream_state_updated,frames_processed,stream_data_moved,datagram_data_moved,migration_state_updated,key_updated,key_discarded,recovery_parameters_set,recovery_metrics_updated,congestion_state_updated,loss_timer_updated,packet_lost,marked_for_retransmit,ecn_state_updated
+: server_listening,
+  connection_started,
+  connection_closed,
+  connection_id_updated,
+  spin_bit_updated,
+  connection_state_updated,
+  path_assigned,
+  mtu_updated,
+  version_information,
+  alpn_information,
+  parameters_set,
+  parameters_restored,
+  packet_sent,
+  packet_received,
+  packet_dropped,
+  packet_buffered,
+  packets_acked,
+  udp_datagrams_sent,
+  udp_datagrams_received,
+  udp_datagram_dropped,
+  stream_state_updated,
+  frames_processed,
+  stream_data_moved,
+  datagram_data_moved,
+  migration_state_updated,
+  key_updated,
+  key_discarded,
+  recovery_parameters_set,
+  recovery_metrics_updated,
+  congestion_state_updated,
+  loss_timer_updated,
+  packet_lost,
+  marked_for_retransmit,
+  ecn_state_updated
 
 Description:
 : Event definitions related to the QUIC transport protocol.


### PR DESCRIPTION
The lack of spaces between commas makes the rendered output way too long. It also makes the markdown annoying to edit. 