### PR TITLE
don't claim that packet number might be available for packet_buffered

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -911,8 +911,8 @@ a `packet_received` event. The event has Base importance level.
 ~~~ cddl
 QUICPacketBuffered = {
 
-    ; primarily packet_type and possible packet_number should be
-    ; filled here as other elements might not be available yet
+    ; primarily packet_type should be filled here as other elements
+    ; might not be available yet
     ? header: PacketHeader
     ? raw: RawInfo
     ? datagram_id: uint32


### PR DESCRIPTION
The header decryption key is derived at the same time as the packet decryption key, therefore there's no way you'd need to buffer a packet for which you can decrypt the packet number, but can't decrypt the packet payload.