### PR TITLE
make the QUICConnectionClosed error code a uint64

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -344,9 +344,9 @@ QUICConnectionClosed = {
     ? application_code: $ApplicationError
 
     ; if connection_code or application_code === "unknown"
-    ? code_bytes: uint32
+    ? code_bytes: uint64
 
-    ? internal_code: uint32
+    ? internal_code: uint64
     ? reason: text
     ? trigger:
         "idle_timeout" /


### PR DESCRIPTION
It's a QUIC varint, so we need a uint64 here.