### PR TITLE
remove circuitous description of default value of StreamFrame.fin

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2085,9 +2085,6 @@ StreamFrame = {
     offset: uint64
     length: uint64
 
-    ; this MAY be set any time,
-    ; but MUST only be set if the value is true
-    ; if absent, the value MUST be assumed to be false
     ? fin: bool .default false
     ? raw: RawInfo
 }


### PR DESCRIPTION
Really, this is not that hard to understand. We don't need to explain how a default value works.