### PR TITLE
improve description of StreamFrame.offset and length

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -2080,8 +2080,7 @@ StreamFrame = {
     frame_type: "stream"
     stream_id: uint64
 
-    ; These two MUST always be set
-    ; If not present in the Frame type, log their default values
+    ; These two MUST always be set, even if not present in the frame type
     offset: uint64
     length: uint64
 


### PR DESCRIPTION
I assume that "default value" is supposed to mean 0, but we can avoid this terminology altogether.