### PR TITLE
remove length and raw from HTTP3FrameCreated and HTTP3FrameParsed

### DIFF
--- a/draft-ietf-quic-qlog-h3-events.md
+++ b/draft-ietf-quic-qlog-h3-events.md
@@ -352,9 +352,8 @@ QUIC layer. For that, see the `stream_data_moved` event in {{QLOG-QUIC}}.
 ~~~ cddl
 HTTP3FrameCreated = {
     stream_id: uint64
-    ? length: uint64
+
     frame: $HTTP3Frame
-    ? raw: RawInfo
 
     * $$http3-framecreated-extension
 }
@@ -373,9 +372,8 @@ received on the QUIC layer. For that, see the `stream_data_moved` event in
 ~~~ cddl
 HTTP3FrameParsed = {
     stream_id: uint64
-    ? length: uint64
+
     frame: $HTTP3Frame
-    ? raw: RawInfo
 
     * $$h3-frameparsed-extension
 }


### PR DESCRIPTION
Fixes #483. Fixes #484. Closes #485.