### PR TITLE
Make loss_timer_updated a generic timer_updated instead

### DIFF
--- a/draft-ietf-quic-qlog-quic-events.md
+++ b/draft-ietf-quic-qlog-quic-events.md
@@ -1403,6 +1403,13 @@ The three main event types are:
 
 In order to indicate an active timer's timeout update, a new `set` event is used.
 
+QUICTimerUpdated events with the `timer_type` set to `ack`or `pto` indicate
+changes to the individual timeouts defined by RFC 9002: the threshold loss
+detection timeout (see {{Section 6.1.2 of QUIC-RECOVERY}}) and the probe timeout
+(see {{Section 6.2 of QUIC-RECOVERY}}). Those set to `loss_timeout` represent
+changes to the multi-modal loss detection timer (see {{Appendix 3 of
+QUIC-RECOVERY}}).
+
 The QUIC protocol conceptually employs a variety of timers, but their usage can
 be implementation-dependent. Implementers can add additional fields to this
 event if needed via `$$quic-timerupdated-extension` or specify other/additional
@@ -1420,7 +1427,8 @@ $TimerType /= "ack" /
 QUICTimerUpdated = {
     ? timer_type: $TimerType
 
-    ; to disambiguate in case there are multiple timers of the same type
+    ; to disambiguate in case there are multiple timers
+    ; of the same type
     ? timer_id: uint64
 
     ; if used for recovery timers, this can be useful information


### PR DESCRIPTION
Fixes #319 

As discussed during the interim, we have a need for logging more timers than just the loss/recovery timers.
As such, we move the `loss_timer_updated` from Recovery to Transport and rename it to `timer_updated`.

There was however still discussion on how to deal with implementations that use a single recovery timer, whether logging all timer resets wouldn't be too chatty (e.g., idle timer), whether we should still have a separate event for recovery timers vs others, etc.

This PR contains an initial proposal, including the timer types I could easily discern in RFC9000 and 9002. 
Feedback on the details from @marten-seemann, @LPardue, @mirjak and @kazuho more than welcome!